### PR TITLE
The session is lazy loading, so if the user doesn't get the segment the ...

### DIFF
--- a/src/Aura/Session/Manager.php
+++ b/src/Aura/Session/Manager.php
@@ -178,6 +178,9 @@ class Manager
      */
     public function destroy()
     {
+        if (! $this->isStarted()) {
+            $this->start();
+        }
         $this->clear();
         return session_destroy();
     }

--- a/tests/Aura/Session/ManagerTest.php
+++ b/tests/Aura/Session/ManagerTest.php
@@ -71,6 +71,22 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->session->isStarted());
     }
     
+    public function testCommitAndDestroy()
+    {
+        // get a test segment and set some data
+        $segment = $this->session->newSegment('test');
+        $segment->foo = 'bar';
+        $segment->baz = 'dib';
+
+        $expect = ['test' => ['foo' => 'bar', 'baz' => 'dib']];
+        $this->assertSame($expect, $_SESSION);
+
+        $this->session->commit();
+        $this->session->destroy();
+        $segment = $this->session->newSegment('test');
+        $this->assertSame([], $_SESSION);
+    }
+
     public function testNewSegment()
     {
         $segment = $this->session->newSegment('test');


### PR DESCRIPTION
...destroy method throws session not started, and cannot be destroyed error. This checks whether the session is started or not and start it and tries the destroy
