### PR TITLE
Move away from references

### DIFF
--- a/src/Segment.php
+++ b/src/Segment.php
@@ -110,7 +110,7 @@ class Segment implements SegmentInterface
     public function setFlash($key, $val)
     {
         $this->resumeOrStartSession();
-        $_SESSION['Aura\Session\Flash\Next'][$this->name][$key] = $val;
+        $_SESSION[Session::FLASH_NEXT][$this->name][$key] = $val;
     }
 
     /**
@@ -125,8 +125,8 @@ class Segment implements SegmentInterface
     public function getFlash($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($_SESSION['Aura\Session\Flash\Now'][$this->name][$key])
-             ? $_SESSION['Aura\Session\Flash\Now'][$this->name][$key]
+        return isset($_SESSION[Session::FLASH_NOW][$this->name][$key])
+             ? $_SESSION[Session::FLASH_NOW][$this->name][$key]
              : $alt;
     }
 
@@ -140,7 +140,7 @@ class Segment implements SegmentInterface
     public function clearFlash()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
+            $_SESSION[Session::FLASH_NEXT][$this->name] = array();
         }
     }
 
@@ -156,8 +156,8 @@ class Segment implements SegmentInterface
     public function getFlashNext($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($_SESSION['Aura\Session\Flash\Next'][$this->name][$key])
-             ? $_SESSION['Aura\Session\Flash\Next'][$this->name][$key]
+        return isset($_SESSION[Session::FLASH_NEXT][$this->name][$key])
+             ? $_SESSION[Session::FLASH_NEXT][$this->name][$key]
              : $alt;
     }
 
@@ -173,8 +173,8 @@ class Segment implements SegmentInterface
     public function setFlashNow($key, $val)
     {
         $this->resumeOrStartSession();
-        $_SESSION['Aura\Session\Flash\Now'][$this->name][$key] = $val;
-        $_SESSION['Aura\Session\Flash\Next'][$this->name][$key] = $val;
+        $_SESSION[Session::FLASH_NOW][$this->name][$key] = $val;
+        $_SESSION[Session::FLASH_NEXT][$this->name][$key] = $val;
     }
 
     /**
@@ -187,8 +187,8 @@ class Segment implements SegmentInterface
     public function clearFlashNow()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session\Flash\Now'][$this->name] = array();
-            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
+            $_SESSION[Session::FLASH_NOW][$this->name] = array();
+            $_SESSION[Session::FLASH_NEXT][$this->name] = array();
         }
     }
 
@@ -203,9 +203,9 @@ class Segment implements SegmentInterface
     public function keepFlash()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array_merge(
-                $_SESSION['Aura\Session\Flash\Next'][$this->name],
-                $_SESSION['Aura\Session\Flash\Now'][$this->name]
+            $_SESSION[Session::FLASH_NEXT][$this->name] = array_merge(
+                $_SESSION[Session::FLASH_NEXT][$this->name],
+                $_SESSION[Session::FLASH_NOW][$this->name]
             );
         }
     }
@@ -257,12 +257,12 @@ class Segment implements SegmentInterface
             $_SESSION[$this->name] = array();
         }
 
-        if (! isset($_SESSION['Aura\Session\Flash\Now'][$this->name])) {
-            $_SESSION['Aura\Session\Flash\Now'][$this->name] = array();
+        if (! isset($_SESSION[Session::FLASH_NOW][$this->name])) {
+            $_SESSION[Session::FLASH_NOW][$this->name] = array();
         }
 
-        if (! isset($_SESSION['Aura\Session\Flash\Next'][$this->name])) {
-            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
+        if (! isset($_SESSION[Session::FLASH_NEXT][$this->name])) {
+            $_SESSION[Session::FLASH_NEXT][$this->name] = array();
         }
     }
 

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -110,7 +110,7 @@ class Segment implements SegmentInterface
     public function setFlash($key, $val)
     {
         $this->resumeOrStartSession();
-        $_SESSION['Aura\Session']['flash_next'][$this->name][$key] = $val;
+        $_SESSION['Aura\Session\Flash\Next'][$this->name][$key] = $val;
     }
 
     /**
@@ -125,8 +125,8 @@ class Segment implements SegmentInterface
     public function getFlash($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($_SESSION['Aura\Session']['flash_now'][$this->name][$key])
-             ? $_SESSION['Aura\Session']['flash_now'][$this->name][$key]
+        return isset($_SESSION['Aura\Session\Flash\Now'][$this->name][$key])
+             ? $_SESSION['Aura\Session\Flash\Now'][$this->name][$key]
              : $alt;
     }
 
@@ -140,7 +140,7 @@ class Segment implements SegmentInterface
     public function clearFlash()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
+            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
         }
     }
 
@@ -156,8 +156,8 @@ class Segment implements SegmentInterface
     public function getFlashNext($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($_SESSION['Aura\Session']['flash_next'][$this->name][$key])
-             ? $_SESSION['Aura\Session']['flash_next'][$this->name][$key]
+        return isset($_SESSION['Aura\Session\Flash\Next'][$this->name][$key])
+             ? $_SESSION['Aura\Session\Flash\Next'][$this->name][$key]
              : $alt;
     }
 
@@ -173,8 +173,8 @@ class Segment implements SegmentInterface
     public function setFlashNow($key, $val)
     {
         $this->resumeOrStartSession();
-        $_SESSION['Aura\Session']['flash_now'][$this->name][$key] = $val;
-        $_SESSION['Aura\Session']['flash_next'][$this->name][$key] = $val;
+        $_SESSION['Aura\Session\Flash\Now'][$this->name][$key] = $val;
+        $_SESSION['Aura\Session\Flash\Next'][$this->name][$key] = $val;
     }
 
     /**
@@ -187,8 +187,8 @@ class Segment implements SegmentInterface
     public function clearFlashNow()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session']['flash_now'][$this->name] = array();
-            $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
+            $_SESSION['Aura\Session\Flash\Now'][$this->name] = array();
+            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
         }
     }
 
@@ -203,9 +203,9 @@ class Segment implements SegmentInterface
     public function keepFlash()
     {
         if ($this->resumeSession()) {
-            $_SESSION['Aura\Session']['flash_next'][$this->name] = array_merge(
-                $_SESSION['Aura\Session']['flash_next'][$this->name],
-                $_SESSION['Aura\Session']['flash_now'][$this->name]
+            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array_merge(
+                $_SESSION['Aura\Session\Flash\Next'][$this->name],
+                $_SESSION['Aura\Session\Flash\Now'][$this->name]
             );
         }
     }
@@ -257,12 +257,12 @@ class Segment implements SegmentInterface
             $_SESSION[$this->name] = array();
         }
 
-        if (! isset($_SESSION['Aura\Session']['flash_now'][$this->name])) {
-            $_SESSION['Aura\Session']['flash_now'][$this->name] = array();
+        if (! isset($_SESSION['Aura\Session\Flash\Now'][$this->name])) {
+            $_SESSION['Aura\Session\Flash\Now'][$this->name] = array();
         }
 
-        if (! isset($_SESSION['Aura\Session']['flash_next'][$this->name])) {
-            $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
+        if (! isset($_SESSION['Aura\Session\Flash\Next'][$this->name])) {
+            $_SESSION['Aura\Session\Flash\Next'][$this->name] = array();
         }
     }
 

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -39,33 +39,6 @@ class Segment implements SegmentInterface
 
     /**
      *
-     * The data in the segment is a reference to a $_SESSION key.
-     *
-     * @var array
-     *
-     */
-    protected $data;
-
-    /**
-     *
-     * Flash values for this request; a reference to a $_SESSION key.
-     *
-     * @var array
-     *
-     */
-    protected $flash_now;
-
-    /**
-     *
-     * Flash values for the next request; a reference to a $_SESSION key.
-     *
-     * @var array
-     *
-     */
-    protected $flash_next;
-
-    /**
-     *
      * Constructor.
      *
      * @param Session $session The session manager.
@@ -91,8 +64,8 @@ class Segment implements SegmentInterface
     public function get($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($this->data[$key])
-             ? $this->data[$key]
+        return isset($_SESSION[$this->name][$key])
+             ? $_SESSION[$this->name][$key]
              : $alt;
     }
 
@@ -108,7 +81,7 @@ class Segment implements SegmentInterface
     public function set($key, $val)
     {
         $this->resumeOrStartSession();
-        $this->data[$key] = $val;
+        $_SESSION[$this->name][$key] = $val;
     }
 
     /**
@@ -121,7 +94,7 @@ class Segment implements SegmentInterface
     public function clear()
     {
         if ($this->resumeSession()) {
-            $this->data = array();
+            $_SESSION[$this->name] = array();
         }
     }
 
@@ -137,7 +110,7 @@ class Segment implements SegmentInterface
     public function setFlash($key, $val)
     {
         $this->resumeOrStartSession();
-        $this->flash_next[$key] = $val;
+        $_SESSION['Aura\Session']['flash_next'][$this->name][$key] = $val;
     }
 
     /**
@@ -152,8 +125,8 @@ class Segment implements SegmentInterface
     public function getFlash($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($this->flash_now[$key])
-             ? $this->flash_now[$key]
+        return isset($_SESSION['Aura\Session']['flash_now'][$this->name][$key])
+             ? $_SESSION['Aura\Session']['flash_now'][$this->name][$key]
              : $alt;
     }
 
@@ -167,7 +140,7 @@ class Segment implements SegmentInterface
     public function clearFlash()
     {
         if ($this->resumeSession()) {
-            $this->flash_next = array();
+            $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
         }
     }
 
@@ -183,8 +156,8 @@ class Segment implements SegmentInterface
     public function getFlashNext($key, $alt = null)
     {
         $this->resumeSession();
-        return isset($this->flash_next[$key])
-             ? $this->flash_next[$key]
+        return isset($_SESSION['Aura\Session']['flash_next'][$this->name][$key])
+             ? $_SESSION['Aura\Session']['flash_next'][$this->name][$key]
              : $alt;
     }
 
@@ -200,8 +173,8 @@ class Segment implements SegmentInterface
     public function setFlashNow($key, $val)
     {
         $this->resumeOrStartSession();
-        $this->flash_now[$key] = $val;
-        $this->flash_next[$key] = $val;
+        $_SESSION['Aura\Session']['flash_now'][$this->name][$key] = $val;
+        $_SESSION['Aura\Session']['flash_next'][$this->name][$key] = $val;
     }
 
     /**
@@ -214,8 +187,8 @@ class Segment implements SegmentInterface
     public function clearFlashNow()
     {
         if ($this->resumeSession()) {
-            $this->flash_now = array();
-            $this->flash_next = array();
+            $_SESSION['Aura\Session']['flash_now'][$this->name] = array();
+            $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
         }
     }
 
@@ -230,9 +203,9 @@ class Segment implements SegmentInterface
     public function keepFlash()
     {
         if ($this->resumeSession()) {
-            $this->flash_next = array_merge(
-                $this->flash_next,
-                $this->flash_now
+            $_SESSION['Aura\Session']['flash_next'][$this->name] = array_merge(
+                $_SESSION['Aura\Session']['flash_next'][$this->name],
+                $_SESSION['Aura\Session']['flash_now'][$this->name]
             );
         }
     }
@@ -246,7 +219,7 @@ class Segment implements SegmentInterface
      */
     protected function isLoaded()
     {
-        return $this->data !== null;
+        return isset($_SESSION[$this->name]);
     }
 
     /**
@@ -291,10 +264,6 @@ class Segment implements SegmentInterface
         if (! isset($_SESSION['Aura\Session']['flash_next'][$this->name])) {
             $_SESSION['Aura\Session']['flash_next'][$this->name] = array();
         }
-
-        $this->data       =& $_SESSION[$this->name];
-        $this->flash_now  =& $_SESSION['Aura\Session']['flash_now'][$this->name];
-        $this->flash_next =& $_SESSION['Aura\Session']['flash_next'][$this->name];
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -203,11 +203,11 @@ class Session
 
     protected function moveFlash()
     {
-        if (! isset($_SESSION['Aura\Session']['flash_next'])) {
-            $_SESSION['Aura\Session']['flash_next'] = array();
+        if (! isset($_SESSION['Aura\Session\Flash\Next'])) {
+            $_SESSION['Aura\Session\Flash\Next'] = array();
         }
-        $_SESSION['Aura\Session']['flash_now'] = $_SESSION['Aura\Session']['flash_next'];
-        $_SESSION['Aura\Session']['flash_next'] = array();
+        $_SESSION['Aura\Session\Flash\Now'] = $_SESSION['Aura\Session\Flash\Next'];
+        $_SESSION['Aura\Session\Flash\Next'] = array();
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -20,6 +20,9 @@ namespace Aura\Session;
  */
 class Session
 {
+    const FLASH_NEXT = 'Aura\Session\Flash\Next';
+    const FLASH_NOW = 'Aura\Session\Flash\Now';
+
     /**
      *
      * A session segment factory.
@@ -203,11 +206,11 @@ class Session
 
     protected function moveFlash()
     {
-        if (! isset($_SESSION['Aura\Session\Flash\Next'])) {
-            $_SESSION['Aura\Session\Flash\Next'] = array();
+        if (! isset($_SESSION[Session::FLASH_NEXT])) {
+            $_SESSION[Session::FLASH_NEXT] = array();
         }
-        $_SESSION['Aura\Session\Flash\Now'] = $_SESSION['Aura\Session\Flash\Next'];
-        $_SESSION['Aura\Session\Flash\Next'] = array();
+        $_SESSION[Session::FLASH_NOW] = $_SESSION[Session::FLASH_NEXT];
+        $_SESSION[Session::FLASH_NEXT] = array();
     }
 
     /**

--- a/tests/src/SegmentTest.php
+++ b/tests/src/SegmentTest.php
@@ -90,7 +90,7 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $this->segment->getFlash('baz'));
 
         // set some current values and make sure they get kept
-        $now =& $_SESSION['Aura\Session']['flash_now'][$this->name];
+        $now =& $_SESSION['Aura\Session\Flash\Now'][$this->name];
         $now['foo'] = 'bar';
         $now['baz'] = 'dib';
         $this->segment->keepFlash();
@@ -170,7 +170,7 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         // should see it in the session
-        $actual = $_SESSION['Aura\Session']['flash_next'][$this->name]['foo'];
+        $actual = $_SESSION['Aura\Session\Flash\Next'][$this->name]['foo'];
         $this->assertSame('bar', $actual);
 
     }

--- a/tests/src/SegmentTest.php
+++ b/tests/src/SegmentTest.php
@@ -90,7 +90,7 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $this->segment->getFlash('baz'));
 
         // set some current values and make sure they get kept
-        $now =& $_SESSION['Aura\Session\Flash\Now'][$this->name];
+        $now =& $_SESSION[Session::FLASH_NOW][$this->name];
         $now['foo'] = 'bar';
         $now['baz'] = 'dib';
         $this->segment->keepFlash();
@@ -170,7 +170,7 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         // should see it in the session
-        $actual = $_SESSION['Aura\Session\Flash\Next'][$this->name]['foo'];
+        $actual = $_SESSION[Session::FLASH_NEXT][$this->name]['foo'];
         $this->assertSame('bar', $actual);
 
     }

--- a/tests/src/SessionTest.php
+++ b/tests/src/SessionTest.php
@@ -56,10 +56,10 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $segment->set('baz', 'dib');
 
         $expect = array(
-            'Aura\Session\Flash\Next' => array(
+            Session::FLASH_NEXT => array(
                 'test' => array(),
             ),
-            'Aura\Session\Flash\Now' => array(
+            Session::FLASH_NOW => array(
                 'test' => array(),
             ),
             'test' => array(
@@ -85,10 +85,10 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         $expect = array(
-            'Aura\Session\Flash\Next' => array(
+            Session::FLASH_NEXT => array(
                 'test' => array(),
             ),
-            'Aura\Session\Flash\Now' => array(
+            Session::FLASH_NOW => array(
                     'test' => array(),
             ),
             'test' => array(
@@ -120,10 +120,10 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         $expect = array(
-            'Aura\Session\Flash\Next' => array(
+            Session::FLASH_NEXT => array(
                 'test' => array(),
             ),
-            'Aura\Session\Flash\Now' => array(
+            Session::FLASH_NOW => array(
                 'test' => array(),
             ),
             'test' => array(

--- a/tests/src/SessionTest.php
+++ b/tests/src/SessionTest.php
@@ -56,13 +56,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $segment->set('baz', 'dib');
 
         $expect = array(
-            'Aura\Session' => array(
-                'flash_next' => array(
-                    'test' => array(),
-                ),
-                'flash_now' => array(
-                    'test' => array(),
-                ),
+            'Aura\Session\Flash\Next' => array(
+                'test' => array(),
+            ),
+            'Aura\Session\Flash\Now' => array(
+                'test' => array(),
             ),
             'test' => array(
                 'foo' => 'bar',
@@ -87,13 +85,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         $expect = array(
-            'Aura\Session' => array(
-                'flash_next' => array(
+            'Aura\Session\Flash\Next' => array(
+                'test' => array(),
+            ),
+            'Aura\Session\Flash\Now' => array(
                     'test' => array(),
-                ),
-                'flash_now' => array(
-                    'test' => array(),
-                ),
             ),
             'test' => array(
                 'foo' => 'bar',
@@ -124,13 +120,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->session->isStarted());
 
         $expect = array(
-            'Aura\Session' => array(
-                'flash_next' => array(
-                    'test' => array(),
-                ),
-                'flash_now' => array(
-                    'test' => array(),
-                ),
+            'Aura\Session\Flash\Next' => array(
+                'test' => array(),
+            ),
+            'Aura\Session\Flash\Now' => array(
+                'test' => array(),
             ),
             'test' => array(
                 'foo' => 'bar',


### PR DESCRIPTION
Using references seems to cause some trouble with propagating flashes from request to request. This removes the references and compresses the flash storage to a single level of depth.
