### PR TITLE
Fix FakeSessionHandler::write() (fixes PHP7 tests)

### DIFF
--- a/tests/unit/src/FakeSessionHandler.php
+++ b/tests/unit/src/FakeSessionHandler.php
@@ -35,5 +35,6 @@ class FakeSessionHandler
     public function write($session_id, $session_data)
     {
         $this->data = $session_data;
+        return true;
     }
 }


### PR DESCRIPTION
The ‘write’ session handler should return a boolean, but this isn’t
enforced prior to PHP 7. So the test (rather than the session) breaks
under PHP 7. Until now…
