### PR TITLE
add support for hash_equals

### DIFF
--- a/src/CsrfToken.php
+++ b/src/CsrfToken.php
@@ -65,6 +65,10 @@ class CsrfToken
      */
     public function isValid($value)
     {
+        if (function_exists('hash_equals')) {
+            return hash_equals($value, $this->getValue());
+        }
+
         return $value === $this->getValue();
     }
 


### PR DESCRIPTION
`hash_equals` is used for preventing timing attack and adopted by Symfony Security Component, Laravel 5 and WordPress.
