### PR TITLE
add support for random_bytes

### DIFF
--- a/src/Randval.php
+++ b/src/Randval.php
@@ -62,6 +62,10 @@ class Randval implements RandvalInterface
             return $this->phpfunc->mcrypt_create_iv($bytes, MCRYPT_DEV_URANDOM);
         }
 
+        if ($this->phpfunc->function_exists('random_bytes')) {
+            return $this->phpfunc->random_bytes($bytes);
+        }
+
         $message = "Cannot generate cryptographically secure random values. "
                  . "Please install extension 'openssl' or 'mcrypt', or use "
                  . "another cryptographically secure implementation.";

--- a/tests/CsrfTokenTest.php
+++ b/tests/CsrfTokenTest.php
@@ -60,10 +60,13 @@ class CsrfTokenTest extends \PHPUnit_Framework_TestCase
         $mcrypt = $token->getValue();
         $this->assertTrue($old != $openssl && $old != $mcrypt);
 
-        // with nothing
-        $this->phpfunc->extensions = array();
-        $this->setExpectedException('Aura\Session\Exception');
-        $token->regenerateValue();
+        if (!$this->phpfunc->function_exists('random_bytes')) {
+            // with nothing
+            $this->phpfunc->extensions = array();
+            $this->setExpectedException('Aura\Session\Exception');
+            $token->regenerateValue();
+        }
+
     }
 
     public function testIsValid()


### PR DESCRIPTION
`random_bytes` can be used in PHP 7.0 alpha and I didn't see perfomance issue in the [result](https://gist.github.com/masakielastic/76ec50728d259626cf14) of benchmark.
