### PR TITLE
[4.x] Add "All Getters" for "Flash" values and "Add"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ echo $segment->get('foo'); // 'bar'
 
 // because the segment is a reference to $_SESSION, we can modify
 // the superglobal directly and the segment values will also change
-$_SESSION['Vendor\Package\ClassName']['zim'] = 'gir'
+$_SESSION['Vendor\Package\ClassName']['zim'] = 'gir';
 echo $segment->get('zim'); // 'gir'
 ?>
 ```
@@ -185,7 +185,7 @@ Calling `destroy()` will also delete the session cookie via `setcookie()`. If we
 // this will be used to delete the session cookie.
 $delete_cookie = function ($name, $path, $domain) use ($response) {
     $response->cookies->delete($name, $path, $domain);
-}
+};
 
 $session = $session_factory->newInstance($_COOKIE, $delete_cookie);
 ?>

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Then, in subsequent requests, we can read the flash value using `getFlash()`:
 <?php
 $segment = $session->getSegment('Vendor\Package\ClassName');
 $message = $segment->getFlash('message'); // 'Hello world!'
+
+// You can also get all the flash messages
+$messages = $segment->getFlashAll();
 ?>
 ```
 

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -101,6 +101,19 @@ class Segment implements SegmentInterface
 
     /**
      *
+     * Append a value to a numeric key in the segment.
+     *
+     * @param mixed $val The value to append.
+     *
+     */
+    public function add($val)
+    {
+        $this->resumeOrStartSession();
+        $_SESSION[$this->name][] = $val;
+    }
+
+    /**
+     *
      * Clear all data from the segment.
      *
      * @return null
@@ -144,6 +157,20 @@ class Segment implements SegmentInterface
     {
         $this->resumeOrStartSession();
         $_SESSION[Session::FLASH_NEXT][$this->name][$key] = $val;
+    }
+
+
+    /**
+     *
+     * Append a flash value with a numeric key for the *next* request.
+     *
+     * @param mixed $val The flash value itself.
+     *
+     */
+    public function addFlash($val)
+    {
+        $this->resumeOrStartSession();
+        $_SESSION[Session::FLASH_NEXT][$this->name][] = $val;
     }
 
     /**
@@ -246,6 +273,20 @@ class Segment implements SegmentInterface
         $this->resumeOrStartSession();
         $_SESSION[Session::FLASH_NOW][$this->name][$key] = $val;
         $_SESSION[Session::FLASH_NEXT][$this->name][$key] = $val;
+    }
+
+    /**
+     *
+     * Append a flash value with a numeric key for the *next* request *and* the current one.
+     *
+     * @param mixed $val The flash value itself.
+     *
+     */
+    public function addFlashNow($val)
+    {
+        $this->resumeOrStartSession();
+        $_SESSION[Session::FLASH_NOW][$this->name][] = $val;
+        $_SESSION[Session::FLASH_NEXT][$this->name][] = $val;
     }
 
     /**

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -167,6 +167,23 @@ class Segment implements SegmentInterface
 
     /**
      *
+     * Gets all the flash values in the *current* request.
+     *
+     * @param mixed $alt An alternative value to return if no flash values are set.
+     *
+     * @return mixed The flash values themselves.
+     *
+     */
+    public function getFlashAll($alt = array())
+    {
+        $this->resumeSession();
+        return isset($_SESSION[Session::FLASH_NOW][$this->name])
+             ? $_SESSION[Session::FLASH_NOW][$this->name]
+             : $alt;
+    }
+
+    /**
+     *
      * Clears flash values for *only* the next request.
      *
      * @return null
@@ -195,6 +212,23 @@ class Segment implements SegmentInterface
         $this->resumeSession();
         return isset($_SESSION[Session::FLASH_NEXT][$this->name][$key])
              ? $_SESSION[Session::FLASH_NEXT][$this->name][$key]
+             : $alt;
+    }
+
+    /**
+     *
+     * Gets all flash values for the *next* request.
+     *
+     * @param mixed $alt An alternative value to return if no flash values set.
+     *
+     * @return mixed The flash values themselves.
+     *
+     */
+    public function getFlashNextAll($alt = array())
+    {
+        $this->resumeSession();
+        return isset($_SESSION[Session::FLASH_NEXT][$this->name])
+             ? $_SESSION[Session::FLASH_NEXT][$this->name]
              : $alt;
     }
 

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -174,7 +174,7 @@ class Segment implements SegmentInterface
      * @return mixed The flash values themselves.
      *
      */
-    public function getFlashAll($alt = array())
+    public function getAllCurrentFlash($alt = array())
     {
         $this->resumeSession();
         return isset($_SESSION[Session::FLASH_NOW][$this->name])
@@ -224,7 +224,7 @@ class Segment implements SegmentInterface
      * @return mixed The flash values themselves.
      *
      */
-    public function getFlashNextAll($alt = array())
+    public function getAllFlashNext($alt = array())
     {
         $this->resumeSession();
         return isset($_SESSION[Session::FLASH_NEXT][$this->name])

--- a/src/SegmentInterface.php
+++ b/src/SegmentInterface.php
@@ -52,6 +52,15 @@ interface SegmentInterface
 
     /**
      *
+     * Append a value to a numeric key in the segment.
+     *
+     * @param mixed $val The value to append.
+     *
+     */
+    public function add($val);
+
+    /**
+     *
      * Clear all data from the segment.
      *
      * @return null
@@ -69,6 +78,15 @@ interface SegmentInterface
      *
      */
     public function setFlash($key, $val);
+
+    /**
+     *
+     * Append a flash value with a numeric key for the *next* request.
+     *
+     * @param mixed $val The flash value itself.
+     *
+     */
+    public function addFlash($val);
 
     /**
      *
@@ -137,6 +155,15 @@ interface SegmentInterface
      *
      */
     public function setFlashNow($key, $val);
+
+    /**
+     *
+     * Append a flash value with a numeric key for the *next* request *and* the current one.
+     *
+     * @param mixed $val The flash value itself.
+     *
+     */
+    public function addFlashNow($val);
 
     /**
      *

--- a/src/SegmentInterface.php
+++ b/src/SegmentInterface.php
@@ -92,7 +92,7 @@ interface SegmentInterface
      * @return mixed The flash values themselves.
      *
      */
-    public function getFlashAll($alt = array());
+    public function getAllCurrentFlash($alt = array());
 
     /**
      *
@@ -125,7 +125,7 @@ interface SegmentInterface
      * @return mixed The flash values themselves.
      *
      */
-    public function getFlashNextAll($alt = array());
+    public function getAllFlashNext($alt = array());
 
     /**
      *

--- a/src/SegmentInterface.php
+++ b/src/SegmentInterface.php
@@ -85,6 +85,17 @@ interface SegmentInterface
 
     /**
      *
+     * Gets all the flash values in the *current* request.
+     *
+     * @param mixed $alt An alternative value to return if no flash values are set.
+     *
+     * @return mixed The flash values themselves.
+     *
+     */
+    public function getFlashAll($alt = array());
+
+    /**
+     *
      * Clears flash values for *only* the next request.
      *
      * @return null
@@ -104,6 +115,17 @@ interface SegmentInterface
      *
      */
     public function getFlashNext($key, $alt = null);
+
+    /**
+     *
+     * Gets all flash values for the *next* request.
+     *
+     * @param mixed $alt An alternative value to return if no flash values set.
+     *
+     * @return mixed The flash values themselves.
+     *
+     */
+    public function getFlashNextAll($alt = array());
 
     /**
      *

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -86,16 +86,16 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $expect = 'bar';
         $expectAll = ['foo' => 'bar'];
         $this->assertSame($expect, $this->segment->getFlashNext('foo'));
-        $this->assertSame($expectAll, $this->segment->getFlashNextAll());
+        $this->assertSame($expectAll, $this->segment->getAllFlashNext());
         $this->assertNull($this->segment->getFlash('foo'));
-        $this->assertSame(array(), $this->segment->getFlashAll());
+        $this->assertSame(array(), $this->segment->getAllCurrentFlash());
 
         // set a value and make it available now
         $this->segment->setFlashNow('baz', 'dib');
         $expect = 'dib';
         $expectAll = ['baz' => 'dib'];
         $this->assertSame($expect, $this->segment->getFlash('baz'));
-        $this->assertSame($expectAll, $this->segment->getFlashAll());
+        $this->assertSame($expectAll, $this->segment->getAllCurrentFlash());
         $this->assertSame($expect, $this->segment->getFlashNext('baz'));
 
         // clear the next values

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -72,19 +72,21 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
     {
         $this->segment->set('foo', 'bar');
         $this->segment->set('baz', 'dib');
+        $this->segment->add('qux');
         $this->assertSame('bar', $this->getValue('foo'));
         $this->assertSame('dib', $this->getValue('baz'));
 
         // now get the data
-        $this->assertSame(array('foo' => 'bar', 'baz' => 'dib'), $this->segment->getSegment());
+        $this->assertSame(array('foo' => 'bar', 'baz' => 'dib', 'qux'), $this->segment->getSegment());
     }
 
     public function testFlash()
     {
         // set a value
         $this->segment->setFlash('foo', 'bar');
+        $this->segment->addFlash('baz');
         $expect = 'bar';
-        $expectAll = ['foo' => 'bar'];
+        $expectAll = ['foo' => 'bar', 'baz'];
         $this->assertSame($expect, $this->segment->getFlashNext('foo'));
         $this->assertSame($expectAll, $this->segment->getAllFlashNext());
         $this->assertNull($this->segment->getFlash('foo'));
@@ -92,8 +94,9 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
 
         // set a value and make it available now
         $this->segment->setFlashNow('baz', 'dib');
+        $this->segment->addFlashNow('qux');
         $expect = 'dib';
-        $expectAll = ['baz' => 'dib'];
+        $expectAll = ['baz' => 'dib', 'qux'];
         $this->assertSame($expect, $this->segment->getFlash('baz'));
         $this->assertSame($expectAll, $this->segment->getAllCurrentFlash());
         $this->assertSame($expect, $this->segment->getFlashNext('baz'));

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -84,13 +84,18 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         // set a value
         $this->segment->setFlash('foo', 'bar');
         $expect = 'bar';
+        $expectAll = ['foo' => 'bar'];
         $this->assertSame($expect, $this->segment->getFlashNext('foo'));
+        $this->assertSame($expectAll, $this->segment->getFlashNextAll());
         $this->assertNull($this->segment->getFlash('foo'));
+        $this->assertSame(array(), $this->segment->getFlashAll());
 
         // set a value and make it available now
         $this->segment->setFlashNow('baz', 'dib');
         $expect = 'dib';
+        $expectAll = ['baz' => 'dib'];
         $this->assertSame($expect, $this->segment->getFlash('baz'));
+        $this->assertSame($expectAll, $this->segment->getFlashAll());
         $this->assertSame($expect, $this->segment->getFlashNext('baz'));
 
         // clear the next values


### PR DESCRIPTION
This is just #47 for 3.x. 
It looks like there was already a `getAll` equivalent: `getSegment`.
