### PR TITLE
Use SegmentInterface as typehint

### DIFF
--- a/src/CsrfToken.php
+++ b/src/CsrfToken.php
@@ -30,7 +30,7 @@ class CsrfToken
      *
      * Session segment for values in this class.
      *
-     * @var Segment
+     * @var SegmentInterface
      *
      */
     protected $segment;
@@ -39,13 +39,13 @@ class CsrfToken
      *
      * Constructor.
      *
-     * @param Segment $segment A segment for values in this class.
+     * @param SegmentInterface $segment A segment for values in this class.
      *
      * @param RandvalInterface $randval A cryptographically-secure random
      * value generator.
      *
      */
-    public function __construct(Segment $segment, RandvalInterface $randval)
+    public function __construct(SegmentInterface $segment, RandvalInterface $randval)
     {
         $this->segment = $segment;
         $this->randval = $randval;


### PR DESCRIPTION
The typehint for the Segment in CsrfToken should be the interface, not the implementation.