### PR TITLE
Fix flash moving if you start session multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,47 @@
-sudo: false
 language: php
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7
+
+matrix:
+    include:
+        - os: linux
+          dist: precise
+          sudo: false
+          php: 5.3
+          env:
+            - TEST_COVERAGE=true
+        - os: linux
+          dist: precise
+          sudo: false
+          php: 5.4
+        - os: linux
+          dist: precise
+          sudo: false
+          php: 5.5
+        - os: linux
+          dist: precise
+          sudo: false
+          php: 5.6
+        - os: linux
+          dist: trusty
+          sudo: false
+          php: 7
+        - os: linux
+          dist: trusty
+          sudo: false
+          php: 7.1
+        - os: linux
+          dist: trusty
+          sudo: false
+          php: hhvm
+        - os: linux
+          dist: trusty
+          sudo: false
+          php: nightly
+
 before_script:
   - composer self-update
   - composer install
 script:
-  - phpunit --coverage-clover=coverage.clover
+  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/phpunit --coverage-clover=coverage.clover ; else vendor/bin/phpunit ; fi
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover ; fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,4 @@
-This release modifies the testing structure and updates other support files.
-
+- (ADD) Add support for hash_equals() in CsrfToken::isValid()
+- (ADD) Add support for random_bytes() in Randval::generate()
+- (TST) Update tests and test support files
+- (DOC) Update license year and remove branch alias

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2015, Aura for PHP
+Copyright (c) 2011-2016, Aura for PHP
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -287,9 +287,10 @@ if ($unsafe && $user->auth->isValid()) {
 
 For a CSRF token to be useful, its random value must be cryptographically
 secure. Using things like `mt_rand()` is insufficient. Aura.Session comes with
-a `Randval` class that implements a `RandvalInterface`, and uses either the
-`openssl` or the `mcrypt` extension to generate a random value. If you do not
-have one of these extensions installed, you will need your own random-value
+a `Randval` class that implements a `RandvalInterface`. It uses the
+[`random_bytes()`](http://php.net/random_bytes) function preferentially, then
+`openssl`, or finally `mcrypt` to generate a random value. If you do not
+have one of these installed, you will need your own random-value
 implementation of the `RandvalInterface`. We suggest a wrapper around
 [RandomLib](https://github.com/ircmaxell/RandomLib).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Alternatively, [download a release](https://github.com/auraphp/Aura.Session/rele
 [![Code Coverage](https://scrutinizer-ci.com/g/auraphp/Aura.Session/badges/coverage.png?b=develop-2)](https://scrutinizer-ci.com/g/auraphp/Aura.Session/)
 [![Build Status](https://travis-ci.org/auraphp/Aura.Session.png?branch=develop-2)](https://travis-ci.org/auraphp/Aura.Session)
 
-To run the unit tests at the command line, issue `composer install` and then `phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`, and [PHPUnit](http://phpunit.de/manual/) to be available as `phpunit`.
+To run the unit tests at the command line, issue `composer install` and then `vendor/bin/phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`.
 
 This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
 you notice compliance oversights, please send a patch via pull request.

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "paragonie/random_compat": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7"
     },
     "require-dev": {
-        "aura/di": "~2.0"
+        "aura/di": "~2.0",
+        "phpunit/phpunit": "~5.7 || ~4.8"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "suggest": {
         "ext-openssl": "OpenSSL generates the best secure CSRF tokens.",
         "ext-mcrypt": "Mcrypt generates the next best secure CSRF tokens.",
-        "ircmaxell/random-lib": "A Library For Generating Secure Random Numbers"
+        "ircmaxell/random-lib": "A Library For Generating Secure Random Numbers",
+        "paragonie/random_compat": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7"
     },
     "require-dev": {
         "aura/di": "~2.0"

--- a/src/CsrfToken.php
+++ b/src/CsrfToken.php
@@ -30,7 +30,7 @@ class CsrfToken
      *
      * Session segment for values in this class.
      *
-     * @var Segment
+     * @var SegmentInterface
      *
      */
     protected $segment;
@@ -39,13 +39,13 @@ class CsrfToken
      *
      * Constructor.
      *
-     * @param Segment $segment A segment for values in this class.
+     * @param SegmentInterface $segment A segment for values in this class.
      *
      * @param RandvalInterface $randval A cryptographically-secure random
      * value generator.
      *
      */
-    public function __construct(Segment $segment, RandvalInterface $randval)
+    public function __construct(SegmentInterface $segment, RandvalInterface $randval)
     {
         $this->segment = $segment;
         $this->randval = $randval;

--- a/src/Randval.php
+++ b/src/Randval.php
@@ -54,16 +54,16 @@ class Randval implements RandvalInterface
     {
         $bytes = 32;
 
+        if ($this->phpfunc->function_exists('random_bytes')) {
+            return $this->phpfunc->random_bytes($bytes);
+        }
+
         if ($this->phpfunc->extension_loaded('openssl')) {
             return $this->phpfunc->openssl_random_pseudo_bytes($bytes);
         }
 
         if ($this->phpfunc->extension_loaded('mcrypt')) {
             return $this->phpfunc->mcrypt_create_iv($bytes, MCRYPT_DEV_URANDOM);
-        }
-
-        if ($this->phpfunc->function_exists('random_bytes')) {
-            return $this->phpfunc->random_bytes($bytes);
         }
 
         $message = "Cannot generate cryptographically secure random values. "

--- a/src/Session.php
+++ b/src/Session.php
@@ -272,7 +272,7 @@ class Session
     public function start()
     {
         $result = $this->phpfunc->session_start();
-        if ($result) {
+        if ($result && ! $this->flash_moved) {
             $this->moveFlash();
         }
         return $result;

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -181,4 +181,29 @@ class SegmentTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->segment->getFlash('foo'));
         $this->assertFalse($this->session->isStarted());
     }
+
+    public function testRestartSessionFlashNotMove()
+    {
+        $this->assertFalse($this->session->isStarted());
+
+        // set it
+        $this->segment->setFlash('foo', 'bar');
+
+        // session should have started
+        $this->assertTrue($this->session->isStarted());
+
+        // should see it in the session
+        $actual = $_SESSION[Session::FLASH_NEXT][$this->name]['foo'];
+        $this->assertSame('bar', $actual);
+
+        $this->session->commit();
+
+        $this->assertFalse($this->session->isStarted());
+
+        $this->session->start();
+
+        // should see it in the session
+        $actual = $_SESSION[Session::FLASH_NEXT][$this->name]['foo'];
+        $this->assertSame('bar', $actual);
+    }
 }


### PR DESCRIPTION
Hi

I had a problem with the flash disappearing on redirect. And figured out that it had to do with me opening and closing the session 2 times in the requests.

I fixed it by adding a check to `start`. It will now look if  `flash_moved` have been set before moving the flash on start.

I don't now if this is something that you want to merge in to the library but I thought I create a Pull request at least.