### PR TITLE
call session_set_cookie_params() only if session not started

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -477,14 +477,16 @@ class Session
      */
     public function setCookieParams(array $params)
     {
-        $this->cookie_params = array_merge($this->cookie_params, $params);
-        $this->phpfunc->session_set_cookie_params(
-            $this->cookie_params['lifetime'],
-            $this->cookie_params['path'],
-            $this->cookie_params['domain'],
-            $this->cookie_params['secure'],
-            $this->cookie_params['httponly']
-        );
+        if (!$this->isStarted()) {
+            $this->cookie_params = array_merge($this->cookie_params, $params);
+            $this->phpfunc->session_set_cookie_params(
+                $this->cookie_params['lifetime'],
+                $this->cookie_params['path'],
+                $this->cookie_params['domain'],
+                $this->cookie_params['secure'],
+                $this->cookie_params['httponly']
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Relates to issue https://github.com/auraphp/Aura.Session/issues/65

This PR prevents the call to session_set_cookie_params() when the
session has started, which prevents the warning in php7.2.

As described in https://bugs.php.net/bug.php?id=75650 it is nonsense to
call session_set_cookie_params() once the session is already running.

See also https://stackoverflow.com/questions/24964699/php-how-can-i-create-multiple-sessions