### PR TITLE
update random val class

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,10 @@ if ($unsafe && $user->auth->isValid()) {
 #### CSRF Value Generation
 
 For a CSRF token to be useful, its random value must be cryptographically
-secure. Using things like `mt_rand()` is insufficient. Aura.Session comes with
-a `Randval` class that implements a `RandvalInterface`, and uses either the
-`openssl` or the `mcrypt` extension to generate a random value. If you do not
-have one of these extensions installed, you will need your own random-value
-implementation of the `RandvalInterface`. We suggest a wrapper around
-[RandomLib](https://github.com/ircmaxell/RandomLib).
+secure. Aura.Session comes with a `Randval` class that implements a
+`RandvalInterface`, and uses default `random_bytes` to generate a
+random value. If you are not satisified,
+you can create your own implementation of the `RandvalInterface`.
 
 ### Session Lifetime
 

--- a/src/Randval.php
+++ b/src/Randval.php
@@ -21,55 +21,13 @@ class Randval implements RandvalInterface
 {
     /**
      *
-     * An object to intercept PHP function calls; this makes testing easier.
-     *
-     * @var Phpfunc
-     *
-     */
-    protected $phpfunc;
-
-    /**
-     *
-     * Constructor.
-     *
-     * @param Phpfunc $phpfunc An object to intercept PHP function calls;
-     * this makes testing easier.
-     *
-     */
-    public function __construct(Phpfunc $phpfunc)
-    {
-        $this->phpfunc = $phpfunc;
-    }
-
-    /**
-     *
      * Returns a cryptographically secure random value.
      *
      * @return string
      *
-     * @throws Exception if neither openssl nor mcrypt is available.
-     *
      */
     public function generate()
     {
-        $bytes = 32;
-
-        if ($this->phpfunc->extension_loaded('openssl')) {
-            return $this->phpfunc->openssl_random_pseudo_bytes($bytes);
-        }
-
-        if ($this->phpfunc->extension_loaded('mcrypt')) {
-            return $this->phpfunc->random_bytes($bytes);
-        }
-
-        if ($this->phpfunc->function_exists('random_bytes')) {
-            return $this->phpfunc->random_bytes($bytes);
-        }
-
-        $message = "Cannot generate cryptographically secure random values. "
-                 . "Please install extension 'openssl' or 'mcrypt', or use "
-                 . "another cryptographically secure implementation.";
-
-        throw new Exception($message);
+        return random_bytes(32);
     }
 }

--- a/src/SessionFactory.php
+++ b/src/SessionFactory.php
@@ -33,7 +33,7 @@ class SessionFactory
         $phpfunc = new Phpfunc;
         return new Session(
             new SegmentFactory,
-            new CsrfTokenFactory(new Randval($phpfunc)),
+            new CsrfTokenFactory(new Randval()),
             $phpfunc,
             $cookies,
             $delete_cookie

--- a/tests/CsrfTokenTest.php
+++ b/tests/CsrfTokenTest.php
@@ -22,7 +22,7 @@ class CsrfTokenTest extends TestCase
 
         $this->session = new Session(
             new SegmentFactory,
-            new CsrfTokenFactory(new Randval($this->phpfunc)),
+            new CsrfTokenFactory(new Randval()),
             $this->phpfunc,
             $_COOKIE
         );

--- a/tests/Issue23Test.php
+++ b/tests/Issue23Test.php
@@ -26,7 +26,7 @@ class Issue23Test extends TestCase
         session_start();
         return new Session(
             new SegmentFactory,
-            new CsrfTokenFactory(new Randval(new Phpfunc)),
+            new CsrfTokenFactory(new Randval()),
             new Phpfunc,
             $cookies
         );

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -24,7 +24,7 @@ class SegmentTest extends TestCase
     {
         return new Session(
             new SegmentFactory,
-            new CsrfTokenFactory(new Randval(new Phpfunc)),
+            new CsrfTokenFactory(new Randval()),
             new Phpfunc,
             $cookies
         );

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -30,7 +30,7 @@ class SessionTest extends TestCase
     {
         return new Session(
             new SegmentFactory,
-            new CsrfTokenFactory(new Randval(new Phpfunc)),
+            new CsrfTokenFactory(new Randval()),
             $this->phpfunc,
             $cookies
         );


### PR DESCRIPTION
For PHP > 7.x , 

I guess we can get rid of the mcrypt and OpenSSL implementations.

By default PHP is providing one. Also in the current RandomVal there is no way to switch between the functions the user needs.

So I believe if they need more secure random generation they can generate their own classses.

Let me know what you guys think.