### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,3 +51,5 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
+          coverage: pcov
           tools: none
           ini-values: assert.exception=1, zend.assertions=1
 
@@ -47,4 +47,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist
 
       - name: Run test suite
-        run: ./vendor/bin/phpunit
+        run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Alternatively, [download a release](https://github.com/auraphp/Aura.Session/rele
 ### Quality
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/auraphp/Aura.Session/badges/quality-score.png?b=4.x)](https://scrutinizer-ci.com/g/auraphp/Aura.Session/?branch=4.x)
+[![codecov](https://codecov.io/gh/auraphp/Aura.Session/branch/4.x/graph/badge.svg)](https://codecov.io/gh/auraphp/Aura.Session)
 [![Continuous Integration](https://github.com/auraphp/Aura.Session/actions/workflows/continuous-integration.yml/badge.svg?branch=4.x)](https://github.com/auraphp/Aura.Session/actions/workflows/continuous-integration.yml)
 
 To run the unit tests at the command line, issue `composer install` and then `phpunit` at the package root. This requires [Composer](http://getcomposer.org/) to be available as `composer`, and [PHPUnit](http://phpunit.de/manual/) to be available as `phpunit`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
This PR is to recover the coverage measurement and badge creation that was previously done by scrutinizer, but now it is done by "codecov". (The previous coverage upload from travis to scrutinizer was unstable.)

Even if you don't feel that the coverage measurement is important, doesn't it make sense to keep the package in its original state and to show the code quality?