### PR TITLE
Feature/redis session hash

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         operating-system:
@@ -28,6 +39,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: redis
           coverage: pcov
           tools: none
           ini-values: assert.exception=1, zend.assertions=1
@@ -47,6 +59,9 @@ jobs:
         run: composer install --no-interaction --prefer-dist
 
       - name: Run test suite
+        env:
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
         run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.0.0
 
+- (ADD) Add `RedisSessionHandler`, an optional `SessionHandlerInterface` implementation that stores each session as a Redis hash (one field per Segment) with a key TTL. It is decoupled from any specific client via `Aura\Session\Redis\RedisClientInterface`, with bundled `PhpredisClient` (ext-redis) and `PredisClient` (predis/predis) adapters. Requires `session.serialize_handler = php_serialize`. No new hard dependency: `ext-redis` and `predis/predis` are listed under `suggest`.
 - (ADD) Depend on the new `aura/session-interface` (`^6.0`) package, which provides the shared session/segment contracts.
 - (CHG) `Session` now implements `Aura\Session_Interface\SessionInterface`.
 - (CHG) `SegmentInterface` no longer declares its own methods; it now composes the shared `Aura\Session_Interface\SegmentInterface` (get/set), `ManageableSegmentInterface` (getSegment/clear/remove), and `FlashSegmentInterface` (flash values). The full method set is unchanged, so existing implementations remain compatible.

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,21 @@
         "php": "^8.1",
         "aura/session-interface": "^6.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Aura\\Session\\": "src/"
         }
     },
     "suggest": {
-        "ext-openssl": "OpenSSL generates the best secure CSRF tokens."
+        "ext-openssl": "OpenSSL generates the best secure CSRF tokens.",
+        "ext-redis": "Use RedisSessionHandler with the phpredis PhpredisClient adapter to store sessions as Redis hashes.",
+        "predis/predis": "Use RedisSessionHandler with the PredisClient adapter to store sessions as Redis hashes."
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0"
+        "phpunit/phpunit": "^10.5 || ^11.0",
+        "predis/predis": "^2.0 || ^3.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,96 @@ $session = $session_factory->newInstance($_COOKIE, $delete_cookie);
 ?>
 ```
 
+## Storing Sessions in Redis
+
+Aura.Session works on top of PHP's native session machinery, so where session
+data is stored is decided by the registered [session save handler](https://www.php.net/manual/en/class.sessionhandler.php).
+Aura.Session ships an optional `RedisSessionHandler` that stores each session as
+a Redis **hash**, with one field per top-level session key (i.e. per Segment),
+instead of a single serialized string. This makes the stored data easy to
+inspect field-by-field and lets Redis manage expiration through a key TTL.
+
+The handler is decoupled from any specific Redis client through
+`Aura\Session\Redis\RedisClientInterface`. Two adapters are bundled:
+
+- `Aura\Session\Redis\PhpredisClient` — for the [phpredis](https://github.com/phpredis/phpredis) extension (`ext-redis`).
+- `Aura\Session\Redis\PredisClient` — for the [predis/predis](https://github.com/predis/predis) package.
+
+You can also implement `RedisClientInterface` yourself to back the handler with
+another client.
+
+### Requirements
+
+The handler splits and rebuilds session data as hash fields, which requires the
+`php_serialize` session serialize handler so that the encoded session is a plain
+`serialize()` of the `$_SESSION` array:
+
+```php
+<?php
+ini_set('session.serialize_handler', 'php_serialize');
+?>
+```
+
+If any other serialize handler is in effect, the handler throws a
+`RuntimeException` explaining the requirement.
+
+### Usage
+
+Register the handler with `session_set_save_handler()` **before** starting the
+session (i.e. before `$session->start()` or the first lazy start).
+
+Using the phpredis extension:
+
+```php
+<?php
+ini_set('session.serialize_handler', 'php_serialize');
+
+$redis = new \Redis();
+$redis->connect('127.0.0.1', 6379);
+
+$handler = new \Aura\Session\RedisSessionHandler(
+    new \Aura\Session\Redis\PhpredisClient($redis)
+);
+session_set_save_handler($handler, true);
+?>
+```
+
+Using predis/predis:
+
+```php
+<?php
+ini_set('session.serialize_handler', 'php_serialize');
+
+$predis = new \Predis\Client(array('host' => '127.0.0.1', 'port' => 6379));
+
+$handler = new \Aura\Session\RedisSessionHandler(
+    new \Aura\Session\Redis\PredisClient($predis)
+);
+session_set_save_handler($handler, true);
+?>
+```
+
+The constructor accepts two optional arguments after the client:
+
+```php
+<?php
+$handler = new \Aura\Session\RedisSessionHandler(
+    $client,
+    3600,             // key TTL in seconds; defaults to session.gc_maxlifetime
+    'my-app-session:' // Redis key prefix; defaults to 'aura-session:'
+);
+?>
+```
+
+Once the handler is registered, use the `Session` object exactly as usual;
+segments, flash values, and CSRF tokens all continue to work unchanged.
+
+> N.b. Because PHP reads and writes the whole session per request, the hash
+> layout is primarily about structured storage and TTL management rather than
+> partial reads/writes. When session data is unchanged, the handler refreshes
+> only the key's TTL (via `session.lazy_write`) instead of rewriting every
+> field.
+
 ## Session Security
 
 ### Session ID Regeneration

--- a/src/Redis/PhpredisClient.php
+++ b/src/Redis/PhpredisClient.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+use Redis;
+
+/**
+ *
+ * Adapts the phpredis `\Redis` client to RedisClientInterface.
+ *
+ * Requires the `redis` (phpredis) extension.
+ *
+ * @package Aura.Session
+ *
+ */
+class PhpredisClient implements RedisClientInterface
+{
+    /**
+     *
+     * The phpredis client.
+     *
+     * @var Redis
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param Redis $redis A connected phpredis client.
+     *
+     */
+    public function __construct(Redis $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function hGetAll(string $key): array
+    {
+        $result = $this->redis->hGetAll($key);
+        return is_array($result) ? $result : array();
+    }
+
+    public function hSet(string $key, string $field, string $value): void
+    {
+        $this->redis->hSet($key, $field, $value);
+    }
+
+    public function del(string $key): void
+    {
+        $this->redis->del($key);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        $this->redis->expire($key, $ttl);
+    }
+
+    public function exists(string $key): bool
+    {
+        return (bool) $this->redis->exists($key);
+    }
+}

--- a/src/Redis/PredisClient.php
+++ b/src/Redis/PredisClient.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+use Predis\ClientInterface;
+
+/**
+ *
+ * Adapts the `predis/predis` client to RedisClientInterface.
+ *
+ * Requires the `predis/predis` package.
+ *
+ * @package Aura.Session
+ *
+ */
+class PredisClient implements RedisClientInterface
+{
+    /**
+     *
+     * The Predis client.
+     *
+     * @var ClientInterface
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param ClientInterface $redis A Predis client.
+     *
+     */
+    public function __construct(ClientInterface $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function hGetAll(string $key): array
+    {
+        return $this->redis->hgetall($key) ?: array();
+    }
+
+    public function hSet(string $key, string $field, string $value): void
+    {
+        $this->redis->hset($key, $field, $value);
+    }
+
+    public function del(string $key): void
+    {
+        $this->redis->del([$key]);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        $this->redis->expire($key, $ttl);
+    }
+
+    public function exists(string $key): bool
+    {
+        return (bool) $this->redis->exists($key);
+    }
+}

--- a/src/Redis/RedisClientInterface.php
+++ b/src/Redis/RedisClientInterface.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+/**
+ *
+ * A minimal, client-neutral contract for the Redis hash operations used by
+ * RedisSessionHandler. Implement this to back the handler with phpredis,
+ * Predis, or any other client.
+ *
+ * @package Aura.Session
+ *
+ */
+interface RedisClientInterface
+{
+    /**
+     *
+     * Returns all fields and values of the hash stored at $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return array<string, string> A map of field => raw stored value; an
+     * empty array when the key does not exist.
+     *
+     */
+    public function hGetAll(string $key): array;
+
+    /**
+     *
+     * Sets $field to $value in the hash stored at $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @param string $field The hash field.
+     *
+     * @param string $value The raw value to store.
+     *
+     * @return void
+     *
+     */
+    public function hSet(string $key, string $field, string $value): void;
+
+    /**
+     *
+     * Deletes $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return void
+     *
+     */
+    public function del(string $key): void;
+
+    /**
+     *
+     * Sets the time-to-live, in seconds, on $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @param int $ttl The time-to-live in seconds.
+     *
+     * @return void
+     *
+     */
+    public function expire(string $key, int $ttl): void;
+
+    /**
+     *
+     * Reports whether $key exists.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return bool
+     *
+     */
+    public function exists(string $key): bool;
+}

--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session;
+
+use Aura\Session\Redis\RedisClientInterface;
+use RuntimeException;
+use SessionHandlerInterface;
+use SessionUpdateTimestampHandlerInterface;
+
+/**
+ *
+ * A session save handler that stores each session as a Redis hash, with one
+ * hash field per top-level session key (i.e. per Segment), instead of a single
+ * serialized string.
+ *
+ * The handler is decoupled from any specific Redis client through
+ * RedisClientInterface; use the bundled PhpredisClient or PredisClient
+ * adapters, or provide your own implementation.
+ *
+ * It requires the `php_serialize` session serialize handler, so that the
+ * encoded session data is a plain `serialize()` of the `$_SESSION` array that
+ * can be split into, and rebuilt from, individual hash fields:
+ *
+ *      ini_set('session.serialize_handler', 'php_serialize');
+ *
+ *      $redis = new \Redis();
+ *      $redis->connect('127.0.0.1', 6379);
+ *      $handler = new \Aura\Session\RedisSessionHandler(
+ *          new \Aura\Session\Redis\PhpredisClient($redis)
+ *      );
+ *      session_set_save_handler($handler, true);
+ *
+ * @package Aura.Session
+ *
+ */
+class RedisSessionHandler implements
+    SessionHandlerInterface,
+    SessionUpdateTimestampHandlerInterface
+{
+    /**
+     *
+     * The Redis client.
+     *
+     * @var RedisClientInterface
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * The session lifetime in seconds, used as the Redis key TTL. When null,
+     * the value of `session.gc_maxlifetime` is used at write time.
+     *
+     * @var int|null
+     *
+     */
+    protected $ttl;
+
+    /**
+     *
+     * A prefix applied to every Redis key.
+     *
+     * @var string
+     *
+     */
+    protected $prefix;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param RedisClientInterface $redis A Redis client adapter.
+     *
+     * @param int|null $ttl The session lifetime in seconds. When null, the
+     * value of `session.gc_maxlifetime` is used at write time.
+     *
+     * @param string $prefix A prefix applied to every Redis key.
+     *
+     */
+    public function __construct(
+        RedisClientInterface $redis,
+        ?int $ttl = null,
+        string $prefix = 'aura-session:'
+    ) {
+        $this->redis = $redis;
+        $this->ttl = $ttl;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     *
+     * Opens the session; asserts that the serialize handler is compatible.
+     *
+     * @param string $save_path The session save path (unused).
+     *
+     * @param string $session_name The session name (unused).
+     *
+     * @return bool
+     *
+     */
+    public function open(string $save_path, string $session_name): bool
+    {
+        $this->assertSerializeHandler();
+        return true;
+    }
+
+    /**
+     *
+     * Closes the session.
+     *
+     * @return bool
+     *
+     */
+    public function close(): bool
+    {
+        return true;
+    }
+
+    /**
+     *
+     * Reads the session data by reassembling the hash fields into the encoded
+     * session string PHP expects.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return string|false The encoded session data, or an empty string.
+     *
+     */
+    public function read(string $session_id): string|false
+    {
+        $this->assertSerializeHandler();
+
+        $fields = $this->redis->hGetAll($this->key($session_id));
+        if ($fields === array()) {
+            return '';
+        }
+
+        $session = array();
+        foreach ($fields as $name => $value) {
+            $session[$name] = unserialize($value);
+        }
+
+        return serialize($session);
+    }
+
+    /**
+     *
+     * Writes the session data, storing each top-level session key as its own
+     * hash field and (re)setting the key's TTL.
+     *
+     * @param string $session_id The session id.
+     *
+     * @param string $session_data The encoded session data.
+     *
+     * @return bool
+     *
+     */
+    public function write(string $session_id, string $session_data): bool
+    {
+        $this->assertSerializeHandler();
+
+        $session = $session_data === '' ? array() : unserialize($session_data);
+        if (! is_array($session)) {
+            throw new RuntimeException(
+                'Could not decode session data; is '
+                . "session.serialize_handler set to 'php_serialize'?"
+            );
+        }
+
+        $key = $this->key($session_id);
+
+        // remove any fields that no longer exist, then write current fields
+        $this->redis->del($key);
+
+        if ($session !== array()) {
+            foreach ($session as $name => $value) {
+                $this->redis->hSet($key, (string) $name, serialize($value));
+            }
+            $this->redis->expire($key, $this->ttl());
+        }
+
+        return true;
+    }
+
+    /**
+     *
+     * Destroys the session.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return bool
+     *
+     */
+    public function destroy(string $session_id): bool
+    {
+        $this->redis->del($this->key($session_id));
+        return true;
+    }
+
+    /**
+     *
+     * Garbage collection is handled by Redis key expiration (TTL), so there is
+     * nothing to do here.
+     *
+     * @param int $maxlifetime The maximum session lifetime (unused).
+     *
+     * @return int|false
+     *
+     */
+    public function gc(int $maxlifetime): int|false
+    {
+        return 0;
+    }
+
+    /**
+     *
+     * Validates a session id, i.e. reports whether the session exists. Lets PHP
+     * avoid regenerating ids for sessions that are already stored.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return bool
+     *
+     */
+    public function validateId(string $session_id): bool
+    {
+        return $this->redis->exists($this->key($session_id));
+    }
+
+    /**
+     *
+     * Updates the session's timestamp when the data has not changed; only the
+     * TTL is refreshed, avoiding a full rewrite of every field.
+     *
+     * @param string $session_id The session id.
+     *
+     * @param string $session_data The encoded session data (unused).
+     *
+     * @return bool
+     *
+     */
+    public function updateTimestamp(string $session_id, string $session_data): bool
+    {
+        $this->redis->expire($this->key($session_id), $this->ttl());
+        return true;
+    }
+
+    /**
+     *
+     * Returns the prefixed Redis key for a session id.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return string
+     *
+     */
+    protected function key(string $session_id): string
+    {
+        return $this->prefix . $session_id;
+    }
+
+    /**
+     *
+     * Returns the TTL to apply to session keys, in seconds.
+     *
+     * @return int
+     *
+     */
+    protected function ttl(): int
+    {
+        if ($this->ttl !== null) {
+            return $this->ttl;
+        }
+
+        return max(1, (int) ini_get('session.gc_maxlifetime'));
+    }
+
+    /**
+     *
+     * Asserts that the session serialize handler is `php_serialize`, which this
+     * handler depends on to split and rebuild session data as hash fields.
+     *
+     * @return void
+     *
+     * @throws RuntimeException when the serialize handler is not `php_serialize`.
+     *
+     */
+    protected function assertSerializeHandler(): void
+    {
+        if (ini_get('session.serialize_handler') !== 'php_serialize') {
+            throw new RuntimeException(
+                'Aura\Session\RedisSessionHandler requires '
+                . "ini_set('session.serialize_handler', 'php_serialize') "
+                . 'so session data can be stored as Redis hash fields.'
+            );
+        }
+    }
+}

--- a/tests/FakeRedisClient.php
+++ b/tests/FakeRedisClient.php
@@ -1,0 +1,42 @@
+<?php
+namespace Aura\Session;
+
+use Aura\Session\Redis\RedisClientInterface;
+
+// An in-memory RedisClientInterface implementation for testing. No extension or
+// server required.
+class FakeRedisClient implements RedisClientInterface
+{
+    /** @var array<string, array<string, string>> */
+    public array $hashes = array();
+
+    /** @var array<string, int> */
+    public array $ttls = array();
+
+    public function hGetAll(string $key): array
+    {
+        return $this->hashes[$key] ?? array();
+    }
+
+    public function hSet(string $key, string $field, string $value): void
+    {
+        $this->hashes[$key][$field] = $value;
+    }
+
+    public function del(string $key): void
+    {
+        unset($this->hashes[$key], $this->ttls[$key]);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        if (isset($this->hashes[$key])) {
+            $this->ttls[$key] = $ttl;
+        }
+    }
+
+    public function exists(string $key): bool
+    {
+        return isset($this->hashes[$key]);
+    }
+}

--- a/tests/RedisSessionHandlerIntegrationTest.php
+++ b/tests/RedisSessionHandlerIntegrationTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Aura\Session;
+
+use Aura\Session\Redis\PhpredisClient;
+use Aura\Session\Redis\PredisClient;
+use Aura\Session\Redis\RedisClientInterface;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as PredisNativeClient;
+use Redis;
+
+// Exercises RedisSessionHandler against a live Redis server, through every
+// available client adapter. Skipped entirely unless REDIS_HOST is set, so local
+// runs without a server are unaffected; CI sets it and provides a service.
+class RedisSessionHandlerIntegrationTest extends TestCase
+{
+    private ?string $restore_serialize_handler = null;
+
+    protected function setUp(): void
+    {
+        if (getenv('REDIS_HOST') === false) {
+            $this->markTestSkipped('REDIS_HOST not set; skipping live Redis tests.');
+        }
+
+        $this->restore_serialize_handler = ini_get('session.serialize_handler');
+        ini_set('session.serialize_handler', 'php_serialize');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->restore_serialize_handler !== null) {
+            ini_set('session.serialize_handler', $this->restore_serialize_handler);
+        }
+    }
+
+    /**
+     * @return array<string, RedisClientInterface>
+     */
+    private function clients(): array
+    {
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = (int) (getenv('REDIS_PORT') ?: 6379);
+
+        $clients = array();
+
+        if (extension_loaded('redis')) {
+            $phpredis = new Redis();
+            $phpredis->connect($host, $port);
+            $clients['phpredis'] = new PhpredisClient($phpredis);
+        }
+
+        if (class_exists(PredisNativeClient::class)) {
+            $clients['predis'] = new PredisClient(
+                new PredisNativeClient(array('host' => $host, 'port' => $port))
+            );
+        }
+
+        if ($clients === array()) {
+            $this->markTestSkipped('No Redis client (phpredis or predis) available.');
+        }
+
+        return $clients;
+    }
+
+    public function testRoundTripAcrossAdapters()
+    {
+        foreach ($this->clients() as $name => $client) {
+            $handler = new RedisSessionHandler($client, 100, 'aura-it:');
+            $id = 'it-' . bin2hex(random_bytes(8));
+
+            $session = array(
+                'identity' => array('userId' => 'asd1234'),
+                'cart' => array('items' => 3),
+            );
+
+            $this->assertTrue($handler->write($id, serialize($session)), $name);
+            $this->assertSame($session, unserialize($handler->read($id)), $name);
+            $this->assertTrue($handler->validateId($id), $name);
+
+            // stale-field removal survives a real round trip
+            $handler->write($id, serialize(array('identity' => array('userId' => 'x'))));
+            $this->assertSame(
+                array('identity' => array('userId' => 'x')),
+                unserialize($handler->read($id)),
+                $name
+            );
+
+            $handler->destroy($id);
+            $this->assertSame('', $handler->read($id), $name);
+            $this->assertFalse($handler->validateId($id), $name);
+        }
+    }
+}

--- a/tests/RedisSessionHandlerTest.php
+++ b/tests/RedisSessionHandlerTest.php
@@ -1,0 +1,132 @@
+<?php
+namespace Aura\Session;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RedisSessionHandlerTest extends TestCase
+{
+    private FakeRedisClient $redis;
+
+    private RedisSessionHandler $handler;
+
+    private ?string $restore_serialize_handler = null;
+
+    protected function setUp(): void
+    {
+        $this->restore_serialize_handler = ini_get('session.serialize_handler');
+        ini_set('session.serialize_handler', 'php_serialize');
+
+        $this->redis = new FakeRedisClient();
+        $this->handler = new RedisSessionHandler($this->redis, 3600, 'test-session:');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->restore_serialize_handler !== null) {
+            ini_set('session.serialize_handler', $this->restore_serialize_handler);
+        }
+    }
+
+    private function encode(array $session): string
+    {
+        // matches how PHP encodes $_SESSION under php_serialize
+        return serialize($session);
+    }
+
+    public function testReadMissingSessionReturnsEmptyString()
+    {
+        $this->assertSame('', $this->handler->read('no-such-id'));
+    }
+
+    public function testWriteStoresEachKeyAsItsOwnHashField()
+    {
+        $session = array(
+            'identity' => array('userId' => 'asd1234'),
+            'cart' => array('items' => 3),
+        );
+
+        $this->assertTrue($this->handler->write('abc', $this->encode($session)));
+
+        // one Redis hash, one field per top-level session key
+        $stored = $this->redis->hashes['test-session:abc'];
+        $this->assertSame(array('identity', 'cart'), array_keys($stored));
+        $this->assertSame($session['identity'], unserialize($stored['identity']));
+        $this->assertSame($session['cart'], unserialize($stored['cart']));
+
+        // TTL applied
+        $this->assertSame(3600, $this->redis->ttls['test-session:abc']);
+    }
+
+    public function testWriteThenReadRoundTrip()
+    {
+        $session = array('identity' => array('userId' => 'asd1234'));
+        $this->handler->write('abc', $this->encode($session));
+
+        $encoded = $this->handler->read('abc');
+        $this->assertSame($session, unserialize($encoded));
+    }
+
+    public function testWriteRemovesStaleFields()
+    {
+        $this->handler->write('abc', $this->encode(array('a' => 1, 'b' => 2)));
+        $this->handler->write('abc', $this->encode(array('a' => 1)));
+
+        $stored = $this->redis->hashes['test-session:abc'];
+        $this->assertSame(array('a'), array_keys($stored));
+    }
+
+    public function testWriteEmptySessionStoresNothing()
+    {
+        $this->handler->write('abc', '');
+        $this->assertArrayNotHasKey('test-session:abc', $this->redis->hashes);
+    }
+
+    public function testDestroy()
+    {
+        $this->handler->write('abc', $this->encode(array('a' => 1)));
+        $this->assertTrue($this->handler->destroy('abc'));
+        $this->assertArrayNotHasKey('test-session:abc', $this->redis->hashes);
+    }
+
+    public function testValidateId()
+    {
+        $this->assertFalse($this->handler->validateId('abc'));
+        $this->handler->write('abc', $this->encode(array('a' => 1)));
+        $this->assertTrue($this->handler->validateId('abc'));
+    }
+
+    public function testUpdateTimestampRefreshesTtlOnly()
+    {
+        $this->handler->write('abc', $this->encode(array('a' => 1)));
+        $this->redis->ttls['test-session:abc'] = 10;
+
+        $this->assertTrue($this->handler->updateTimestamp('abc', $this->encode(array('a' => 1))));
+        $this->assertSame(3600, $this->redis->ttls['test-session:abc']);
+    }
+
+    public function testGcReturnsZero()
+    {
+        $this->assertSame(0, $this->handler->gc(1440));
+    }
+
+    public function testTtlFallsBackToGcMaxlifetime()
+    {
+        $prev = ini_get('session.gc_maxlifetime');
+        ini_set('session.gc_maxlifetime', '1234');
+
+        $handler = new RedisSessionHandler($this->redis, null, 'test-session:');
+        $handler->write('abc', $this->encode(array('a' => 1)));
+        $this->assertSame(1234, $this->redis->ttls['test-session:abc']);
+
+        ini_set('session.gc_maxlifetime', (string) $prev);
+    }
+
+    public function testRequiresPhpSerializeHandler()
+    {
+        ini_set('session.serialize_handler', 'php');
+
+        $this->expectException(RuntimeException::class);
+        $this->handler->read('abc');
+    }
+}


### PR DESCRIPTION
# RedisSessionHandler — design notes and implications

This branch adds a **hash-based** `RedisSessionHandler`: each session is stored
as a Redis hash with one field per top-level session key (i.e. per Segment),
per the request in [issue #95](https://github.com/auraphp/Aura.Session/issues/95).

These notes record what the design does and does **not** buy, so the tradeoffs
are explicit before merging. A companion branch implements the alternative
**string-based** handler that mirrors mainstream framework practice; it can be
merged later, and the two approaches should be weighed against each other.

## What this handler does

- Implements `SessionHandlerInterface` + `SessionUpdateTimestampHandlerInterface`.
- Stores each session as a Redis hash, one field per Segment, via a
  client-neutral `Aura\Session\Redis\RedisClientInterface` (phpredis / Predis
  adapters bundled).
- Applies a key TTL (`EXPIRE`), defaulting to `session.gc_maxlifetime`.
- Refreshes only the TTL when session data is unchanged (`lazy_write`).
- Leaves expiry/GC to Redis TTL (`gc()` is a no-op).

## Implication 1 — the cited efficiency win is NOT realized here

Issue #95 references Redis's guidance that hashes avoid "extracting and storing
the entire session." That benefit only exists when the session manager reads and
writes **individual fields**. PHP's `SessionHandlerInterface` does not: it calls
`read($id)` **once** at `session_start()` (expecting the whole session back) and
`write($id, $wholeSession)` **once** at `session_write_close()`.

So, under the native session lifecycle, a hash transfers the **entire** session
every request, exactly like a string. Storing as a hash yields **structured
storage and per-field TTL potential** — not the transfer/processing efficiency
the blog describes. No Redis version changes this; partial-field access
(`HGET`/`HSET`) has always existed and is simply never exercised by PHP's
session API.

## Implication 2 — it is slower than a string, not faster

Local benchmark (5 segments, ~5k writes, localhost Redis):

| approach                                   | ms/op | round trips/write |
|--------------------------------------------|------:|------------------:|
| per-field `hSet` (this handler, unbatched) | 0.153 | N + 2             |
| per-field `hSet`, pipelined                | 0.028 | 1                 |
| single string `SET ... EX`                 | 0.023 | 1                 |

The per-field write costs one round trip per field; over a real network (RTT
0.2–1 ms) this dominates. Pipelining the write (one `MULTI`/pipeline round trip)
brings it close to the string, but never beats it. **If this branch is chosen,
the write should be pipelined.**

## Implication 3 — it requires `php_serialize`

To split the encoded session into per-key hash fields, the handler requires:

    ini_set('session.serialize_handler', 'php_serialize');

so the blob is a plain `serialize($_SESSION)`. Under the default `php` handler,
splitting would require a hand-written parser of PHP's session grammar. The
handler throws a `RuntimeException` if a different serialize handler is active.
The string-based alternative has no such requirement.

## Implication 4 — it diverges from ecosystem practice

Symfony (`RedisSessionHandler`), Laravel, and the phpredis native handler all
store sessions as a **single string with a TTL** (`SETEX` + `GET` + `EXPIRE`,
`lazy_write`, `UNLINK` on delete), precisely because of Implication 1. No
mainstream PHP session handler stores native sessions as hashes.

## Where a hash genuinely earns its place

The hash layout is worthwhile if the goal moves beyond `SessionHandlerInterface`:

- **Per-field TTL** (`HEXPIRE`, Redis 7.4+) — e.g. flash values expiring
  independently of the identity segment. Strings cannot do this.
- **A Segment-backed-on-Redis store** that bypasses `$_SESSION` and reads/writes
  individual fields lazily (`HGET`/`HSET` per Segment). This *does* deliver the
  blog's efficiency, but it is a separate, larger redesign — not a drop-in
  `SessionHandlerInterface` — and would rework flash/CSRF handling.

## Recommendation for reviewers

- If the goal is a solid, fast, familiar Redis handler now: prefer the
  **string** branch (matches Symfony; no `php_serialize` requirement).
- If the goal is field-level introspection / future per-field TTL: keep this
  **hash** branch, but pipeline the write first.
- The true efficiency of issue #95 needs the **Segment-backed** redesign; track
  it as a separate enhancement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis-backed session storage with configurable expiration and key prefixes.
  * Added support for both phpredis and Predis Redis clients.
  * Added compatibility with shared session and segment interfaces.
  * Added explicit return types across session and segment APIs.

* **Documentation**
  * Added setup guidance and examples for configuring Redis session storage.

* **Tests**
  * Added unit and integration coverage for Redis session handling, including persistence, expiration, cleanup, and client adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->