### PR TITLE
Add string based redis session handler

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        # renovate: datasource=docker depName=redis
+        image: redis:8.2-alpine@sha256:30abb90e62f14b737010746def3ba99cc79fe19dcdb3d37b41f21fc62e7da19d
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         operating-system:
@@ -25,6 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: redis
           coverage: pcov
           tools: none
           ini-values: assert.exception=1, zend.assertions=1
@@ -44,6 +57,9 @@ jobs:
         run: composer install --no-interaction --prefer-dist
 
       - name: Run test suite
+        env:
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
         run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.0.0
 
+- (ADD) Add `RedisSessionHandler`, an optional `SessionHandlerInterface` implementation that stores each session as a single Redis string with a key TTL (the approach used by Symfony, Laravel, and the phpredis native handler). It refreshes only the TTL when data is unchanged (`lazy_write`), destroys empty sessions, and leaves expiry to Redis. It is decoupled from any specific client via `Aura\Session\Redis\RedisClientInterface`, with bundled `PhpredisClient` (ext-redis) and `PredisClient` (predis/predis) adapters. No hard Redis-client dependency: `ext-redis` and `predis/predis` are listed under `suggest`.
 - (ADD) Depend on the new `aura/session-interface` (`^7.0`) package, which provides the shared session/segment contracts.
 - (CHG) `Session` now implements `Aura\Session_Interface\SessionInterface`.
 - (CHG) `SegmentInterface` no longer declares its own methods; it now composes the shared `Aura\Session_Interface\SegmentInterface` (get/set), `ManageableSegmentInterface` (getSegment/clear/remove), and `FlashSegmentInterface` (flash values). The full method set is unchanged, so existing implementations remain compatible.

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,13 @@
         }
     },
     "suggest": {
-        "ext-openssl": "OpenSSL generates the best secure CSRF tokens."
+        "ext-openssl": "OpenSSL generates the best secure CSRF tokens.",
+        "ext-redis": "Use RedisSessionHandler with the phpredis PhpredisClient adapter to store sessions in Redis.",
+        "predis/predis": "Use RedisSessionHandler with the PredisClient adapter to store sessions in Redis."
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0"
+        "phpunit/phpunit": "^10.5 || ^11.0",
+        "predis/predis": "^2.0 || ^3.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,6 +204,72 @@ function currentUserId(SessionInterface $session): ?int
 ?>
 ```
 
+## Storing Sessions in Redis
+
+Aura.Session works on top of PHP's native session machinery, so where session
+data is stored is decided by the registered [session save handler](https://www.php.net/manual/en/class.sessionhandler.php).
+Aura.Session ships an optional `RedisSessionHandler` that stores each session as
+a single string in Redis with a key TTL — the same approach used by Symfony,
+Laravel, and the phpredis native handler. Redis manages expiration through the
+TTL, and when session data is unchanged only the TTL is refreshed
+(`session.lazy_write`).
+
+The handler is decoupled from any specific Redis client through
+`Aura\Session\Redis\RedisClientInterface`. Two adapters are bundled:
+
+- `Aura\Session\Redis\PhpredisClient` — for the [phpredis](https://github.com/phpredis/phpredis) extension (`ext-redis`).
+- `Aura\Session\Redis\PredisClient` — for the [predis/predis](https://github.com/predis/predis) package.
+
+You can also implement `RedisClientInterface` yourself to back the handler with
+another client.
+
+### Usage
+
+Register the handler with `session_set_save_handler()` **before** starting the
+session (i.e. before `$session->start()` or the first lazy start).
+
+Using the phpredis extension:
+
+```php
+<?php
+$redis = new \Redis();
+$redis->connect('127.0.0.1', 6379);
+
+$handler = new \Aura\Session\RedisSessionHandler(
+    new \Aura\Session\Redis\PhpredisClient($redis)
+);
+session_set_save_handler($handler, true);
+?>
+```
+
+Using predis/predis:
+
+```php
+<?php
+$predis = new \Predis\Client(array('host' => '127.0.0.1', 'port' => 6379));
+
+$handler = new \Aura\Session\RedisSessionHandler(
+    new \Aura\Session\Redis\PredisClient($predis)
+);
+session_set_save_handler($handler, true);
+?>
+```
+
+The constructor accepts two optional arguments after the client:
+
+```php
+<?php
+$handler = new \Aura\Session\RedisSessionHandler(
+    $client,
+    3600,             // key TTL in seconds; defaults to session.gc_maxlifetime
+    'my-app-session:' // Redis key prefix; defaults to 'aura-session:'
+);
+?>
+```
+
+Once the handler is registered, use the `Session` object exactly as usual;
+segments, flash values, and CSRF tokens all continue to work unchanged.
+
 ## Session Security
 
 ### Session ID Regeneration

--- a/src/Redis/PhpredisClient.php
+++ b/src/Redis/PhpredisClient.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+use Redis;
+
+/**
+ *
+ * Adapts the phpredis `\Redis` client to RedisClientInterface.
+ *
+ * Requires the `redis` (phpredis) extension.
+ *
+ * @package Aura.Session
+ *
+ */
+class PhpredisClient implements RedisClientInterface
+{
+    /**
+     *
+     * The phpredis client.
+     *
+     * @var Redis
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param Redis $redis A connected phpredis client.
+     *
+     */
+    public function __construct(Redis $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function get(string $key): ?string
+    {
+        $value = $this->redis->get($key);
+        return $value === false ? null : $value;
+    }
+
+    public function setEx(string $key, int $ttl, string $value): void
+    {
+        $this->redis->setEx($key, $ttl, $value);
+    }
+
+    public function del(string $key): void
+    {
+        // UNLINK reclaims memory in a background thread; fall back to DEL on
+        // servers older than Redis 4.0.
+        if (method_exists($this->redis, 'unlink')) {
+            $this->redis->unlink($key);
+            return;
+        }
+
+        $this->redis->del($key);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        $this->redis->expire($key, $ttl);
+    }
+
+    public function exists(string $key): bool
+    {
+        return (bool) $this->redis->exists($key);
+    }
+}

--- a/src/Redis/PredisClient.php
+++ b/src/Redis/PredisClient.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+use Predis\ClientInterface;
+
+/**
+ *
+ * Adapts the `predis/predis` client to RedisClientInterface.
+ *
+ * Requires the `predis/predis` package.
+ *
+ * @package Aura.Session
+ *
+ */
+class PredisClient implements RedisClientInterface
+{
+    /**
+     *
+     * The Predis client.
+     *
+     * @var ClientInterface
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param ClientInterface $redis A Predis client.
+     *
+     */
+    public function __construct(ClientInterface $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function get(string $key): ?string
+    {
+        return $this->redis->get($key);
+    }
+
+    public function setEx(string $key, int $ttl, string $value): void
+    {
+        $this->redis->setex($key, $ttl, $value);
+    }
+
+    public function del(string $key): void
+    {
+        $this->redis->del([$key]);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        $this->redis->expire($key, $ttl);
+    }
+
+    public function exists(string $key): bool
+    {
+        return (bool) $this->redis->exists($key);
+    }
+}

--- a/src/Redis/RedisClientInterface.php
+++ b/src/Redis/RedisClientInterface.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session\Redis;
+
+/**
+ *
+ * A minimal, client-neutral contract for the Redis operations used by
+ * RedisSessionHandler. Implement this to back the handler with phpredis,
+ * Predis, or any other client.
+ *
+ * @package Aura.Session
+ *
+ */
+interface RedisClientInterface
+{
+    /**
+     *
+     * Returns the string value stored at $key, or null when it does not exist.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return string|null
+     *
+     */
+    public function get(string $key): ?string;
+
+    /**
+     *
+     * Stores $value at $key with a time-to-live of $ttl seconds, in a single
+     * atomic operation.
+     *
+     * @param string $key The Redis key.
+     *
+     * @param int $ttl The time-to-live in seconds.
+     *
+     * @param string $value The value to store.
+     *
+     * @return void
+     *
+     */
+    public function setEx(string $key, int $ttl, string $value): void;
+
+    /**
+     *
+     * Deletes $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return void
+     *
+     */
+    public function del(string $key): void;
+
+    /**
+     *
+     * Sets the time-to-live, in seconds, on $key.
+     *
+     * @param string $key The Redis key.
+     *
+     * @param int $ttl The time-to-live in seconds.
+     *
+     * @return void
+     *
+     */
+    public function expire(string $key, int $ttl): void;
+
+    /**
+     *
+     * Reports whether $key exists.
+     *
+     * @param string $key The Redis key.
+     *
+     * @return bool
+     *
+     */
+    public function exists(string $key): bool;
+}

--- a/src/RedisSessionHandler.php
+++ b/src/RedisSessionHandler.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/mit-license.php MIT
+ *
+ */
+namespace Aura\Session;
+
+use Aura\Session\Redis\RedisClientInterface;
+use SessionHandlerInterface;
+use SessionUpdateTimestampHandlerInterface;
+
+/**
+ *
+ * A session save handler that stores each session as a single Redis string with
+ * a key TTL, mirroring the approach used by mainstream frameworks (Symfony,
+ * Laravel, and the phpredis native handler).
+ *
+ * The handler is decoupled from any specific Redis client through
+ * RedisClientInterface; use the bundled PhpredisClient or PredisClient
+ * adapters, or provide your own implementation:
+ *
+ *      $redis = new \Redis();
+ *      $redis->connect('127.0.0.1', 6379);
+ *      $handler = new \Aura\Session\RedisSessionHandler(
+ *          new \Aura\Session\Redis\PhpredisClient($redis)
+ *      );
+ *      session_set_save_handler($handler, true);
+ *
+ * @package Aura.Session
+ *
+ */
+class RedisSessionHandler implements
+    SessionHandlerInterface,
+    SessionUpdateTimestampHandlerInterface
+{
+    /**
+     *
+     * The Redis client.
+     *
+     * @var RedisClientInterface
+     *
+     */
+    protected $redis;
+
+    /**
+     *
+     * The session lifetime in seconds, used as the Redis key TTL. When null,
+     * the value of `session.gc_maxlifetime` is used at write time.
+     *
+     * @var int|null
+     *
+     */
+    protected $ttl;
+
+    /**
+     *
+     * A prefix applied to every Redis key.
+     *
+     * @var string
+     *
+     */
+    protected $prefix;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param RedisClientInterface $redis A Redis client adapter.
+     *
+     * @param int|null $ttl The session lifetime in seconds. When null, the
+     * value of `session.gc_maxlifetime` is used at write time.
+     *
+     * @param string $prefix A prefix applied to every Redis key.
+     *
+     */
+    public function __construct(
+        RedisClientInterface $redis,
+        ?int $ttl = null,
+        string $prefix = 'aura-session:'
+    ) {
+        $this->redis = $redis;
+        $this->ttl = $ttl;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     *
+     * Opens the session.
+     *
+     * @param string $save_path The session save path (unused).
+     *
+     * @param string $session_name The session name (unused).
+     *
+     * @return bool
+     *
+     */
+    public function open(string $save_path, string $session_name): bool
+    {
+        return true;
+    }
+
+    /**
+     *
+     * Closes the session.
+     *
+     * @return bool
+     *
+     */
+    public function close(): bool
+    {
+        return true;
+    }
+
+    /**
+     *
+     * Reads the encoded session data.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return string|false The encoded session data, or an empty string.
+     *
+     */
+    public function read(string $session_id): string|false
+    {
+        return $this->redis->get($this->key($session_id)) ?? '';
+    }
+
+    /**
+     *
+     * Writes the encoded session data with a fresh TTL. Empty sessions are
+     * destroyed rather than stored.
+     *
+     * @param string $session_id The session id.
+     *
+     * @param string $session_data The encoded session data.
+     *
+     * @return bool
+     *
+     */
+    public function write(string $session_id, string $session_data): bool
+    {
+        if ($session_data === '') {
+            return $this->destroy($session_id);
+        }
+
+        $this->redis->setEx($this->key($session_id), $this->ttl(), $session_data);
+        return true;
+    }
+
+    /**
+     *
+     * Destroys the session.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return bool
+     *
+     */
+    public function destroy(string $session_id): bool
+    {
+        $this->redis->del($this->key($session_id));
+        return true;
+    }
+
+    /**
+     *
+     * Garbage collection is handled by Redis key expiration (TTL), so there is
+     * nothing to do here.
+     *
+     * @param int $maxlifetime The maximum session lifetime (unused).
+     *
+     * @return int|false
+     *
+     */
+    public function gc(int $maxlifetime): int|false
+    {
+        return 0;
+    }
+
+    /**
+     *
+     * Validates a session id, i.e. reports whether the session exists. Lets PHP
+     * avoid regenerating ids for sessions that are already stored.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return bool
+     *
+     */
+    public function validateId(string $session_id): bool
+    {
+        return $this->redis->exists($this->key($session_id));
+    }
+
+    /**
+     *
+     * Updates the session's timestamp when the data has not changed; only the
+     * TTL is refreshed, avoiding a rewrite of the payload.
+     *
+     * @param string $session_id The session id.
+     *
+     * @param string $session_data The encoded session data (unused).
+     *
+     * @return bool
+     *
+     */
+    public function updateTimestamp(string $session_id, string $session_data): bool
+    {
+        $this->redis->expire($this->key($session_id), $this->ttl());
+        return true;
+    }
+
+    /**
+     *
+     * Returns the prefixed Redis key for a session id.
+     *
+     * @param string $session_id The session id.
+     *
+     * @return string
+     *
+     */
+    protected function key(string $session_id): string
+    {
+        return $this->prefix . $session_id;
+    }
+
+    /**
+     *
+     * Returns the TTL to apply to session keys, in seconds.
+     *
+     * @return int
+     *
+     */
+    protected function ttl(): int
+    {
+        if ($this->ttl !== null) {
+            return $this->ttl;
+        }
+
+        return max(1, (int) ini_get('session.gc_maxlifetime'));
+    }
+}

--- a/tests/FakeRedisClient.php
+++ b/tests/FakeRedisClient.php
@@ -1,0 +1,43 @@
+<?php
+namespace Aura\Session;
+
+use Aura\Session\Redis\RedisClientInterface;
+
+// An in-memory RedisClientInterface implementation for testing. No extension or
+// server required.
+class FakeRedisClient implements RedisClientInterface
+{
+    /** @var array<string, string> */
+    public array $values = array();
+
+    /** @var array<string, int> */
+    public array $ttls = array();
+
+    public function get(string $key): ?string
+    {
+        return $this->values[$key] ?? null;
+    }
+
+    public function setEx(string $key, int $ttl, string $value): void
+    {
+        $this->values[$key] = $value;
+        $this->ttls[$key] = $ttl;
+    }
+
+    public function del(string $key): void
+    {
+        unset($this->values[$key], $this->ttls[$key]);
+    }
+
+    public function expire(string $key, int $ttl): void
+    {
+        if (isset($this->values[$key])) {
+            $this->ttls[$key] = $ttl;
+        }
+    }
+
+    public function exists(string $key): bool
+    {
+        return isset($this->values[$key]);
+    }
+}

--- a/tests/RedisSessionHandlerIntegrationTest.php
+++ b/tests/RedisSessionHandlerIntegrationTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Aura\Session;
+
+use Aura\Session\Redis\PhpredisClient;
+use Aura\Session\Redis\PredisClient;
+use Aura\Session\Redis\RedisClientInterface;
+use PHPUnit\Framework\TestCase;
+use Predis\Client as PredisNativeClient;
+use Redis;
+
+// Exercises RedisSessionHandler against a live Redis server, through every
+// available client adapter. Skipped entirely unless REDIS_HOST is set, so local
+// runs without a server are unaffected; CI sets it and provides a service.
+class RedisSessionHandlerIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (getenv('REDIS_HOST') === false) {
+            $this->markTestSkipped('REDIS_HOST not set; skipping live Redis tests.');
+        }
+    }
+
+    /**
+     * @return array<string, RedisClientInterface>
+     */
+    private function clients(): array
+    {
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = (int) (getenv('REDIS_PORT') ?: 6379);
+
+        $clients = array();
+
+        if (extension_loaded('redis')) {
+            $phpredis = new Redis();
+            $phpredis->connect($host, $port);
+            $clients['phpredis'] = new PhpredisClient($phpredis);
+        }
+
+        if (class_exists(PredisNativeClient::class)) {
+            $clients['predis'] = new PredisClient(
+                new PredisNativeClient(array('host' => $host, 'port' => $port))
+            );
+        }
+
+        if ($clients === array()) {
+            $this->markTestSkipped('No Redis client (phpredis or predis) available.');
+        }
+
+        return $clients;
+    }
+
+    public function testRoundTripAcrossAdapters()
+    {
+        foreach ($this->clients() as $name => $client) {
+            $handler = new RedisSessionHandler($client, 100, 'aura-it:');
+            $id = 'it-' . bin2hex(random_bytes(8));
+            $data = 'identity|a:1:{s:6:"userId";s:7:"asd1234";}';
+
+            $this->assertTrue($handler->write($id, $data), $name);
+            $this->assertSame($data, $handler->read($id), $name);
+            $this->assertTrue($handler->validateId($id), $name);
+
+            // updating with new data replaces the payload
+            $handler->write($id, 'identity|a:1:{s:6:"userId";s:1:"x";}');
+            $this->assertSame('identity|a:1:{s:6:"userId";s:1:"x";}', $handler->read($id), $name);
+
+            $handler->destroy($id);
+            $this->assertSame('', $handler->read($id), $name);
+            $this->assertFalse($handler->validateId($id), $name);
+        }
+    }
+}

--- a/tests/RedisSessionHandlerTest.php
+++ b/tests/RedisSessionHandlerTest.php
@@ -80,10 +80,12 @@ class RedisSessionHandlerTest extends TestCase
         $prev = ini_get('session.gc_maxlifetime');
         ini_set('session.gc_maxlifetime', '1234');
 
-        $handler = new RedisSessionHandler($this->redis, null, 'test-session:');
-        $handler->write('abc', 'something');
-        $this->assertSame(1234, $this->redis->ttls['test-session:abc']);
-
-        ini_set('session.gc_maxlifetime', (string) $prev);
+        try {
+            $handler = new RedisSessionHandler($this->redis, null, 'test-session:');
+            $handler->write('abc', 'something');
+            $this->assertSame(1234, $this->redis->ttls['test-session:abc']);
+        } finally {
+            ini_set('session.gc_maxlifetime', (string) $prev);
+        }
     }
 }

--- a/tests/RedisSessionHandlerTest.php
+++ b/tests/RedisSessionHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+namespace Aura\Session;
+
+use PHPUnit\Framework\TestCase;
+
+class RedisSessionHandlerTest extends TestCase
+{
+    private FakeRedisClient $redis;
+
+    private RedisSessionHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->redis = new FakeRedisClient();
+        $this->handler = new RedisSessionHandler($this->redis, 3600, 'test-session:');
+    }
+
+    public function testReadMissingSessionReturnsEmptyString()
+    {
+        $this->assertSame('', $this->handler->read('no-such-id'));
+    }
+
+    public function testWriteStoresValueWithTtl()
+    {
+        $data = 'identity|a:1:{s:6:"userId";s:7:"asd1234";}';
+
+        $this->assertTrue($this->handler->write('abc', $data));
+        $this->assertSame($data, $this->redis->values['test-session:abc']);
+        $this->assertSame(3600, $this->redis->ttls['test-session:abc']);
+    }
+
+    public function testWriteThenReadRoundTrip()
+    {
+        $data = 'identity|a:1:{s:6:"userId";s:7:"asd1234";}';
+        $this->handler->write('abc', $data);
+
+        $this->assertSame($data, $this->handler->read('abc'));
+    }
+
+    public function testWriteEmptySessionDestroysInstead()
+    {
+        $this->handler->write('abc', 'something');
+        $this->assertTrue($this->handler->write('abc', ''));
+
+        $this->assertArrayNotHasKey('test-session:abc', $this->redis->values);
+    }
+
+    public function testDestroy()
+    {
+        $this->handler->write('abc', 'something');
+        $this->assertTrue($this->handler->destroy('abc'));
+        $this->assertArrayNotHasKey('test-session:abc', $this->redis->values);
+    }
+
+    public function testValidateId()
+    {
+        $this->assertFalse($this->handler->validateId('abc'));
+        $this->handler->write('abc', 'something');
+        $this->assertTrue($this->handler->validateId('abc'));
+    }
+
+    public function testUpdateTimestampRefreshesTtlOnly()
+    {
+        $this->handler->write('abc', 'something');
+        $this->redis->ttls['test-session:abc'] = 10;
+
+        $this->assertTrue($this->handler->updateTimestamp('abc', 'something'));
+        $this->assertSame(3600, $this->redis->ttls['test-session:abc']);
+        // payload untouched
+        $this->assertSame('something', $this->redis->values['test-session:abc']);
+    }
+
+    public function testGcReturnsZero()
+    {
+        $this->assertSame(0, $this->handler->gc(1440));
+    }
+
+    public function testTtlFallsBackToGcMaxlifetime()
+    {
+        $prev = ini_get('session.gc_maxlifetime');
+        ini_set('session.gc_maxlifetime', '1234');
+
+        $handler = new RedisSessionHandler($this->redis, null, 'test-session:');
+        $handler->write('abc', 'something');
+        $this->assertSame(1234, $this->redis->ttls['test-session:abc']);
+
+        ini_set('session.gc_maxlifetime', (string) $prev);
+    }
+}


### PR DESCRIPTION
# Add RedisSessionHandler (string + TTL) — supersedes #100, addresses #95

## Summary

Adds an optional `RedisSessionHandler` that stores sessions in Redis, using the
**single-string + key-TTL** approach that Symfony, Laravel, and the phpredis
native handler all use. It implements `SessionHandlerInterface` and
`SessionUpdateTimestampHandlerInterface`, and is decoupled from any specific
client through a small `Aura\Session\Redis\RedisClientInterface`, with bundled
adapters for **phpredis** and **predis/predis**.

Zero-dependency policy is preserved: `ext-redis` and `predis/predis` are listed
under `suggest`, never `require`. The handler is simply unusable without one of
them installed; the rest of the library is unaffected.

> This is the **string-based** alternative to the hash-based branch
> (`feature/redis-session-hash`, #100). See that branch's
> `docs/redis-session-handler-notes.md` for the full analysis. In short: under
> PHP's `SessionHandlerInterface`, the session is always read/written whole, so
> the hash layout does not deliver the transfer efficiency issue #95 cites, and
> benchmarks slower than a string. This branch follows the ecosystem consensus.

## What it does

- `read` → `GET`
- `write` → `SETEX key ttl data` (atomic data + expiry); an empty session is
  destroyed rather than stored
- `destroy` → `UNLINK` (falls back to `DEL` on Redis < 4.0)
- `updateTimestamp` → `EXPIRE` only — when session data is unchanged, the payload
  is not rewritten (`session.lazy_write`)
- `gc` → no-op; expiry is delegated to the Redis key TTL
- `validateId` → `EXISTS`

TTL defaults to `session.gc_maxlifetime` and the key prefix defaults to
`aura-session:`; both are configurable via the constructor.

## Usage

```php
// phpredis
$redis = new \Redis();
$redis->connect('127.0.0.1', 6379);
$handler = new \Aura\Session\RedisSessionHandler(
    new \Aura\Session\Redis\PhpredisClient($redis)
);
session_set_save_handler($handler, true);

// predis/predis
$predis = new \Predis\Client(['host' => '127.0.0.1', 'port' => 6379]);
$handler = new \Aura\Session\RedisSessionHandler(
    new \Aura\Session\Redis\PredisClient($predis)
);
session_set_save_handler($handler, true);
```

`session_set_save_handler()` must be called before the session starts. Segments,
flash values, and CSRF tokens continue to work unchanged.

## Best practices adopted

Mirrors the mainstream handlers: atomic `SETEX`, `lazy_write` via
`SessionUpdateTimestampHandlerInterface`, empty-session cleanup, `UNLINK` over
`DEL`, TTL-owned expiry, and multi-client support. No serialize-handler
requirement (unlike the hash approach, which needs `php_serialize`).

## Files

- `src/Redis/RedisClientInterface.php` — client-neutral contract (`get`, `setEx`,
  `del`, `expire`, `exists`)
- `src/Redis/PhpredisClient.php`, `src/Redis/PredisClient.php` — adapters
- `src/RedisSessionHandler.php` — the handler
- `tests/FakeRedisClient.php` — in-memory adapter for unit tests
- `tests/RedisSessionHandlerTest.php` — unit tests (no extension/server needed)
- `tests/RedisSessionHandlerIntegrationTest.php` — live test across both
  adapters, skipped unless `REDIS_HOST` is set

## Testing / CI

- Unit tests run everywhere with the in-memory fake.
- CI adds a `redis` service container (pinned to a versioned tag + digest),
  installs `ext-redis`, and sets `REDIS_HOST`/`REDIS_PORT` so the integration
  test exercises both adapters against a real server.
- Verified locally against Redis on PHP 8.4: full suite green (46 tests, 142
  assertions), both phpredis and Predis 3.x adapters covered.

## Notes

- No BC breaks; purely additive.
- Issue #95 deliberately stays open. This gives Aura.Session a Redis
  handler, but the per-field transfer efficiency #95 asks for cannot be reached
  through `SessionHandlerInterface` at all — PHP hands the handler the whole
  encoded session on every `write()`, so a hash moves exactly as many bytes as a
  string. That work needs a Segment-backed store that reads and writes
  individual fields lazily, bypassing `$_SESSION`. #95 stays open to track it.
- #100 is the hash-based alternative to this PR; it should be closed unmerged.
- Rebased onto current `7.x`, so this now sits on `php: ^8.4` and
  `aura/session-interface: ^7.0@beta`, and the CI matrix is 8.4/8.5.
- `predis/predis` added to `require-dev` (`^2.0 || ^3.0`) to test the Predis
  adapter. No `minimum-stability` override is needed — the beta constraint on
  `7.x` resolves `aura/session-interface` on its own.
