### PR TITLE
Add the shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+# Releasing this package: Actions -> Release -> Run workflow, pick the branch
+# (7.x) and type the version. Or from a terminal:
+#
+#     gh workflow run release.yml --ref 7.x -f version=7.0.0
+#
+# The shared workflow creates the tag itself, and only after every check has
+# passed. Do not tag by hand -- Packagist derives versions from tags, so a tag
+# is a published version the moment it exists.
+#
+# Release notes come from this package's own CHANGELOG.md. The version you type
+# must match the version at the top of the change log -- or, for a pre-release
+# such as 7.0.0-alpha1, its base version, so that alphas and betas do not each
+# need a change log section of their own.
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 7.0.0'
+        required: true
+        type: string
+
+jobs:
+  release:
+    uses: auraphp/bin/.github/workflows/release.yml@master
+    permissions:
+      contents: write
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
This package had no `release.yml`, so there was no way to release it through Actions — the same gap that was just filled in auraphp/Aura.Session_Interface#1.

Same caller workflow the rest of the suite uses: Actions -> Release -> pick the branch and type the version. The shared workflow in `auraphp/bin` runs the checks, takes the notes from `CHANGELOG.md`, and creates the tag only if everything passed.

The change log heads with `## 7.0.0` and carries no `unreleased` marker, so a `7.0.0-beta1` would be accepted against it (a pre-release matches its base version), as would the stable `7.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)