### PR TITLE
Pin the shared release workflow to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   release:
-    uses: auraphp/bin/.github/workflows/release.yml@master
+    uses: auraphp/bin/.github/workflows/release.yml@v1.0.0
     permissions:
       contents: write
     with:


### PR DESCRIPTION
CodeRabbit flagged the `@master` reference on auraphp/Aura.Auth#119: the called workflow receives `contents: write` and creates release tags, so a change in `auraphp/bin` could alter this package's release path without any change here.

`auraphp/bin` is now tagged `v1.0.0`, and this points at that tag. Moving to a later version becomes a deliberate one-line bump in this file rather than something that happens on its own.

The same pin is going to every package that uses the shared workflow, so they stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)