### PR TITLE
Add Segment::getFlashAll() and Segment::getFlashNextAll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.0.0
 
 - (ADD) Add `RedisSessionHandler`, an optional `SessionHandlerInterface` implementation that stores each session as a single Redis string with a key TTL (the approach used by Symfony, Laravel, and the phpredis native handler). It refreshes only the TTL when data is unchanged (`lazy_write`), destroys empty sessions, and leaves expiry to Redis. It is decoupled from any specific client via `Aura\Session\Redis\RedisClientInterface`, with bundled `PhpredisClient` (ext-redis) and `PredisClient` (predis/predis) adapters. No hard Redis-client dependency: `ext-redis` and `predis/predis` are listed under `suggest`.
+- (ADD) Add `Segment::getFlashAll()` and `Segment::getFlashNextAll()`, which return every flash value for the current or the next request, so flash messages can be rendered without knowing their keys. Both return an empty array when nothing is set. Originally proposed by Jake Johns in #47/#52.
 - (ADD) Depend on the new `aura/session-interface` (`^7.0`) package, which provides the shared session/segment contracts.
 - (CHG) `Session` now implements `Aura\Session_Interface\SessionInterface`.
 - (CHG) `SegmentInterface` no longer declares its own methods; it now composes the shared `Aura\Session_Interface\SegmentInterface` (get/set), `ManageableSegmentInterface` (getSegment/clear/remove), and `FlashSegmentInterface` (flash values). The full method set is unchanged, so existing implementations remain compatible.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,6 +97,25 @@ Using `setFlash()` makes the flash value available only in the *next* request, n
 
 Using `getFlash()` returns only the values that are available now from having been set in the previous request. To read a value that will be available in the next request, use `getFlashNext($key, $alt)`.
 
+#### Reading All Flash Values
+
+Rendering a list of flash messages usually means reading them without knowing
+the keys in advance. `getFlashAll()` returns every flash value available in the
+current request, and `getFlashNextAll()` every value set for the next one:
+
+```php
+<?php
+$segment = $session->getSegment('Vendor\Package\ClassName');
+foreach ($segment->getFlashAll() as $key => $message) {
+    echo $message;
+}
+?>
+```
+
+Both return an empty array when nothing is set, so the result is always safe to
+iterate. Neither takes an alternative value: unlike `getFlash()`, there is no
+"key set to null" case to tell apart from "key not set".
+
 #### Keeping and Clearing Flash Values
 
 Sometimes we will want to keep the flash values in the current request for the next request.  We can do so on a per-segment basis by calling the _Segment_ `keepFlash()` method.
@@ -183,8 +202,8 @@ use:
 - `Aura\Session_Interface\ManageableSegmentInterface` — whole-segment
   management (`getSegment()`, `clear()`, `remove()`).
 - `Aura\Session_Interface\FlashSegmentInterface` — flash values (`setFlash()`,
-  `getFlash()`, `getFlashNext()`, `setFlashNow()`, `clearFlash()`,
-  `clearFlashNow()`, `keepFlash()`).
+  `getFlash()`, `getFlashAll()`, `getFlashNext()`, `getFlashNextAll()`,
+  `setFlashNow()`, `clearFlash()`, `clearFlashNow()`, `keepFlash()`).
 
 The Aura.Session `Aura\Session\SegmentInterface` composes all three segment
 contracts, and `Aura\Session\Segment` implements it. To type-hint against the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,9 +112,11 @@ foreach ($segment->getFlashAll() as $key => $message) {
 ?>
 ```
 
-Both return an empty array when nothing is set, so the result is always safe to
-iterate. Neither takes an alternative value: unlike `getFlash()`, there is no
-"key set to null" case to tell apart from "key not set".
+Both return an empty array when no keys are set, so the result is always safe to
+iterate. Neither takes an alternative value, because the array already carries
+that information: a key holding `null` is still present in it, and
+`array_key_exists()` tells it apart from a key that was never set. That is a
+distinction `getFlash()` cannot make, since it falls back to `$alt` for both.
 
 #### Keeping and Clearing Flash Values
 

--- a/src/Segment.php
+++ b/src/Segment.php
@@ -171,6 +171,20 @@ class Segment implements SegmentInterface
 
     /**
      *
+     * Gets all the flash values for the *current* request.
+     *
+     * @return array All the flash values for the current request; empty when
+     * there are none.
+     *
+     */
+    public function getFlashAll(): array
+    {
+        $this->resumeSession();
+        return $_SESSION[Session::FLASH_NOW][$this->name] ?? array();
+    }
+
+    /**
+     *
      * Clears flash values for *only* the next request.
      *
      * @return void
@@ -200,6 +214,20 @@ class Segment implements SegmentInterface
         return isset($_SESSION[Session::FLASH_NEXT][$this->name][$key])
              ? $_SESSION[Session::FLASH_NEXT][$this->name][$key]
              : $alt;
+    }
+
+    /**
+     *
+     * Gets all the flash values for the *next* request.
+     *
+     * @return array All the flash values for the next request; empty when
+     * there are none.
+     *
+     */
+    public function getFlashNextAll(): array
+    {
+        $this->resumeSession();
+        return $_SESSION[Session::FLASH_NEXT][$this->name] ?? array();
     }
 
     /**

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -278,4 +278,68 @@ class SegmentTest extends TestCase
         $actual = $_SESSION[Session::FLASH_NEXT][$this->name]['foo'];
         $this->assertSame('bar', $actual);
     }
+
+    public function testGetFlashAll()
+    {
+        // nothing set yet
+        $this->assertSame(array(), $this->segment->getFlashAll());
+        $this->assertSame(array(), $this->segment->getFlashNextAll());
+
+        // values for the next request only
+        $this->segment->setFlash('foo', 'bar');
+        $this->segment->setFlash('baz', 'dib');
+        $this->assertSame(
+            array('foo' => 'bar', 'baz' => 'dib'),
+            $this->segment->getFlashNextAll()
+        );
+        $this->assertSame(array(), $this->segment->getFlashAll());
+
+        // a value for the current request as well
+        $this->segment->setFlashNow('zim', 'gir');
+        $this->assertSame(array('zim' => 'gir'), $this->segment->getFlashAll());
+        $this->assertSame(
+            array('foo' => 'bar', 'baz' => 'dib', 'zim' => 'gir'),
+            $this->segment->getFlashNextAll()
+        );
+
+        // clearing the next request leaves the current one alone
+        $this->segment->clearFlash();
+        $this->assertSame(array(), $this->segment->getFlashNextAll());
+        $this->assertSame(array('zim' => 'gir'), $this->segment->getFlashAll());
+
+        // clearing both empties them
+        $this->segment->clearFlashNow();
+        $this->assertSame(array(), $this->segment->getFlashAll());
+        $this->assertSame(array(), $this->segment->getFlashNextAll());
+    }
+
+    public function testGetFlashAllDoesNotStartSession()
+    {
+        $this->assertFalse($this->session->isStarted());
+        $this->assertSame(array(), $this->segment->getFlashAll());
+        $this->assertSame(array(), $this->segment->getFlashNextAll());
+        $this->assertFalse($this->session->isStarted());
+    }
+
+    public function testGetFlashAllResumesSessionBeforeReading()
+    {
+        // ---- request 1: set a flash for the next request ----
+        $this->segment->setFlash('foo', 'bar');
+        $this->segment->setFlash('baz', 'dib');
+
+        $name = $this->session->getName();
+        $id = $this->session->getId();
+        $this->session->commit();
+
+        // ---- request 2: brand new Session object so flash_moved is false ----
+        $cookies = array($name => $id);
+        $session = $this->newSession($cookies);
+        $segment = $session->getSegment($this->name);
+
+        // getFlashAll() resumes, promotes FLASH_NEXT -> FLASH_NOW, and returns it
+        $this->assertSame(
+            array('foo' => 'bar', 'baz' => 'dib'),
+            $segment->getFlashAll()
+        );
+    }
 }

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -313,6 +313,21 @@ class SegmentTest extends TestCase
         $this->assertSame(array(), $this->segment->getFlashNextAll());
     }
 
+    public function testGetFlashAllKeepsKeysHoldingNull()
+    {
+        $this->segment->setFlashNow('nullkey', null);
+
+        // getFlash() cannot tell "set to null" from "never set"
+        $this->assertSame('alt', $this->segment->getFlash('nullkey', 'alt'));
+        $this->assertSame('alt', $this->segment->getFlash('missing', 'alt'));
+
+        // the all-getter keeps the key, so the caller can
+        $all = $this->segment->getFlashAll();
+        $this->assertTrue(array_key_exists('nullkey', $all));
+        $this->assertNull($all['nullkey']);
+        $this->assertFalse(array_key_exists('missing', $all));
+    }
+
     public function testGetFlashAllDoesNotStartSession()
     {
         $this->assertFalse($this->session->isStarted());


### PR DESCRIPTION
## Summary

Implements the two flash all-getters on `Segment`:

```php
$segment->getFlashAll();     // every flash value in the *current* request
$segment->getFlashNextAll(); // every flash value set for the *next* request
```

Reading flash values previously required knowing their keys in advance, so
rendering a list of flash messages meant reaching into
`$_SESSION[Session::FLASH_NOW][$name]` directly, defeating the point of the
segment. `getSegment()` already covers this for plain values; these two do the
same for flash.

## Origin

Proposed by @jakejohns in 2016 (#47, #52) and deferred for one reason: adding
methods to `SegmentInterface` breaks every implementer. The contracts now live
in `aura/session-interface`, whose 7.0 line is still a pre-release, so the
change is free to make.

Only the "all getters" half of #52 is implemented here. Its other half —
`add()` / `addFlash()` / `addFlashNow()`, which append with numeric keys — is
left out deliberately: those mix integer and string keys in one array, making
`getSegment()`'s return shape unpredictable, and `set()` with an explicit array
covers the same ground more clearly. #52 can be closed once this merges.

## On the signature

Neither method takes an `$alt` argument, following `getSegment()` rather than
the key-based getters. In this library every `$alt` is on a key-based getter
(`get()`, `getFlash()`, `getFlashNext()`), where it disambiguates "key not set"
from "key set to null". An all-getter has no such ambiguity: there are values or
there are none, and none is `[]`.

Both return `array` rather than `?array`, so the result is always safe to
`foreach`. This differs slightly from `getSegment()`, which returns `null` when
the segment is unset.

## Behaviour

- Both resume (never start) the session first, like the other flash getters.
- `getFlashAll()` reads `FLASH_NOW`, `getFlashNextAll()` reads `FLASH_NEXT`, so
  `setFlashNow()` shows up in both and `clearFlash()` empties only the latter.
- Empty array when nothing is set.

## Tests

Three added to `SegmentTest`: the main behaviour across `setFlash()`,
`setFlashNow()`, `clearFlash()` and `clearFlashNow()`; that neither starts a
session; and that they resume and promote `FLASH_NEXT` → `FLASH_NOW` across a
request boundary. Full suite green: 39 tests, 129 assertions.

## Merge order

Depends on auraphp/Aura.Session_Interface#3, which declares these two methods on
`FlashSegmentInterface`. **Merge that and tag `7.0.0-beta2` first.** Nothing
breaks in the meantime — a class may implement more than its interface requires,
which is why CI passes against `7.0.0-beta1` — but the contract is only complete
once beta2 is out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added methods to retrieve all flash values for the current request or the next request.
  * These methods return an empty array when no flash values are available.
* **Documentation**
  * Added usage guidance and examples for reading all flash values.
* **Tests**
  * Added coverage for flash retrieval, clearing values, session handling, and request-to-request promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->